### PR TITLE
Use __GLIBC_PREREQ only when __GLIBC__ is defined

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -115,7 +115,7 @@
 
 #endif
 
-#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 11)
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 11)
 
 /* glibc 2.11 seems to have working 6 argument sycall. Use the
    glibc supplied syscall in this case.


### PR DESCRIPTION
The way __GLIBC_PREREQ() is currently used means that it's evaluated
even if __GLIBC__ is not defined. But obviously, __GLIBC_PREREQ will
not exist if __GLIBC__ is not defined, causing build failures on C
libraries not defining __GLIBC__ such as the musl C library.
Uclibc pretends to be glibc so we need to exclude it from the check.

Patch originally taken from:
https://github.com/voidlinux/void-packages/blob/master/srcpkgs/numactl/patches/musl.patch

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
[Bernd: Added uClibc exclusion]
Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Thomas: improve patch description.]