### PR TITLE
Fix usage of __GLIBC_PREREQ for non-glibc toolchains

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -115,7 +115,11 @@
 
 #endif
 
-#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 11)
+#ifndef __GLIBC_PREREQ
+# define __GLIBC_PREREQ(x,y) 0
+#endif
+
+#if defined(__GLIBC__) && __GLIBC_PREREQ(2, 11)
 
 /* glibc 2.11 seems to have working 6 argument sycall. Use the
    glibc supplied syscall in this case.


### PR DESCRIPTION
The way __GLIBC_PREREQ() is currently used means that it's evaluated
even if __GLIBC__ is not defined. But obviously, __GLIBC_PREREQ will
not exist if __GLIBC__ is not defined, causing build failures on C
libraries not defining __GLIBC__ such as the musl C library.

The first try to fix the problem was wrong, sorry. This patch reverts https://github.com/numactl/numactl/commit/3770bdc4fa7b9059db5cd2aa8bb09b50fa15e456 and adds the proper fix.

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>
[Bernd: Reworked to fix uClibc]
Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Thomas: improve patch description.]