### PR TITLE
Fix for numa_police_memory()

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -860,7 +860,7 @@ void numa_police_memory(void *mem, size_t size)
 	int pagesize = numa_pagesize_int();
 	unsigned long i; 
 	for (i = 0; i < size; i += pagesize)
-		asm volatile("" :: "r" (((volatile unsigned char *)mem)[i]));
+        ((volatile char*)mem)[i] = ((volatile char*)mem)[i];
 }
 
 make_internal_alias(numa_police_memory);


### PR DESCRIPTION
Implementation of this function was based on outdated assumption
that memory read causes page fault (and allocation of physical memory).

This assumption is not true for Linux since 2.6.32 (a13ea5b); Uninitialized
memory is backed by zero_page until time of first write.

This patch makes numa_policy_memory() works as expected, by rewriting
(instead of just reading) first byte of every page.