### PR TITLE
Pkgconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@
 /test-suite.log
 /test/*.log
 /test/*.trs
+
+# pkg-config file
+numa.pc

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 
 ACLOCAL_AMFLAGS = -I m4
+CLEANFILES =
 
 AM_CPPFLAGS = -Wall
 
@@ -141,3 +142,20 @@ TESTS = \
 # These are known to be broken:
 #	test/prefered
 #	test/randmap
+
+SED_PROCESS = \
+        $(AM_V_GEN)$(SED) \
+        -e 's,@VERSION\@,$(VERSION),g' \
+        -e 's,@prefix\@,$(prefix),g' \
+        -e 's,@exec_prefix\@,$(exec_prefix),g' \
+        -e 's,@libdir\@,$(libdir),g' \
+        -e 's,@includedir\@,$(includedir),g' \
+        < $< > $@ || rm $@
+
+%.pc: %.pc.in Makefile
+	$(SED_PROCESS)
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = numa.pc
+EXTRA_DIST += numa.pc.in
+CLEANFILES += numa.pc

--- a/numa.pc.in
+++ b/numa.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: numa
+Description: NUMA policy library
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lnuma

--- a/numastat.c
+++ b/numastat.c
@@ -1312,7 +1312,7 @@ void add_pids_from_pattern_search(char *pattern) {
 		}
 		// Next copy cmdline file contents onto end of buffer.  Do it a
 		// character at a time to convert nulls to spaces.
-		char fname[64];
+		char fname[272];
 		snprintf(fname, sizeof(fname), "/proc/%s/cmdline", namelist[ix]->d_name);
 		FILE *fs = fopen(fname, "r");
 		if (fs) {


### PR DESCRIPTION
Add pkg-config file for NUMA library so other tools can add autoconf dependencies on libnuma.

Also fix 2 compiler warnings.