### PR TITLE
Allow building on ARM systems

### DIFF
--- a/syscall.c
+++ b/syscall.c
@@ -109,6 +109,10 @@
 
 #define __NR_migrate_pages	272
 
+#elif defined(__arm__)
+/* https://bugs.debian.org/796802 */
+#warning "ARM does not implement the migrate_pages() syscall"
+
 #elif !defined(DEPS_RUN)
 #error "Add syscalls for your architecture or update kernel headers"
 #endif
@@ -211,7 +215,12 @@ long WEAK set_mempolicy(int mode, const unsigned long *nmask,
 long WEAK migrate_pages(int pid, unsigned long maxnode,
 	const unsigned long *frommask, const unsigned long *tomask)
 {
+#if defined(__NR_migrate_pages)
 	return syscall(__NR_migrate_pages, pid, maxnode, frommask, tomask);
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
 }
 
 long WEAK move_pages(int pid, unsigned long count,


### PR DESCRIPTION
While 32-bit ARM systems do not support NUMA, it is useful to be able
to build libnuma for these systems. Distributions would then not need to
special case ARM builds for software that uses libnuma when available.
libnuma's API requires users to check for NUMA support at runtime using
numa_available() which will just always return -1 on ARM.

  https://bugs.debian.org/796802
  https://launchpad.net/bugs/1711478

Original patches by Uwe Kleine-König <uwe+debian@kleine-koenig.org> and
Tiago Stürmer Daitx <tiago.daitx@ubuntu.com>.

Signed-off-by: dann frazier <dannf@ubuntu.com>