### PR TITLE
Add "NAME" section to numastat manpage

### DIFF
--- a/numastat.8
+++ b/numastat.8
@@ -1,5 +1,5 @@
 .TH "numastat" "8" "1.0.0" "Bill Gray" "Administration"
-.SH "numastat"
+.SH NAME
 .LP
 \fBnumastat\fP \- Show per-NUMA-node memory statistics for processes and the operating system
 .SH "SYNTAX"


### PR DESCRIPTION
The numastat manpage is missing a "NAME" section, which appears to be due
to a typo. This causes problems with commands like apropos and whatis.

Discovered by lintian(1):
  https://lintian.debian.org/tags/manpage-has-bad-whatis-entry.html

Signed-off-by: dann frazier <dannf@ubuntu.com>