### PR TITLE
Use Ubuntu 16.04 in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: c
 
 compiler:


### PR DESCRIPTION
This should get us newer compilers.

Followed the instructions in:
https://docs.travis-ci.com/user/reference/trusty/