### PR TITLE
Correct calculation of nr_nodes and re-enable move_pages test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -134,6 +134,7 @@ TESTS = \
 	test/checkaffinity \
 	test/checktopology \
 	test/distance \
+	test/move_pages \
 	test/nodemap \
 	test/numademo \
 	test/regress \

--- a/test/move_pages.c
+++ b/test/move_pages.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
 
 	pagesize = getpagesize();
 
-	nr_nodes = numa_max_node();
+	nr_nodes = numa_max_node() + 1;
 
 	if (nr_nodes < 2) {
 		printf("A minimum of 2 nodes is required for this test.\n");


### PR DESCRIPTION
This was pointed out by @bjsprakash in #8.

After the bug is corrected, we can re-enable the test in `make check` and also Travis-CI.

@andikleen Please review.

Fixes #8