### PR TITLE
Fix: node_list with memory-less nodes

### DIFF
--- a/numademo.c
+++ b/numademo.c
@@ -307,7 +307,7 @@ void get_node_list()
         node_to_use = (int *)malloc(numnodes * sizeof(int));
         max_node = numa_max_node();
         for (a = 0; a <= max_node; a++) {
-                if(numa_node_size(a, &free_node_sizes) != -1)
+                if (numa_node_size(a, &free_node_sizes) > 0)
                         node_to_use[got_nodes++] = a;
         }
 }


### PR DESCRIPTION
Patch adds check to avoid memory-less nodes while traversing till max node, and this also prevents nodes_to_use sysmalloc failure as nodes_to_use is malloc'ed with numa_num_configured_nodes which
returns the number of nodes configured with memory.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>