### PR TITLE
Fix: move_pages test for non-contiguous nodes

### DIFF
--- a/test/move_pages.c
+++ b/test/move_pages.c
@@ -21,6 +21,24 @@ int *status;
 int *nodes;
 int errors;
 int nr_nodes;
+int *node_to_use;
+
+int get_node_list()
+{
+        int a, got_nodes = 0, max_node, numnodes;
+        long free_node_sizes;
+
+        numnodes = numa_num_configured_nodes();
+        node_to_use = (int *)malloc(numnodes * sizeof(int));
+        max_node = numa_max_node();
+        for (a = 0; a <= max_node; a++) {
+                if (numa_node_size(a, &free_node_sizes) > 0)
+                        node_to_use[got_nodes++] = a;
+        }
+        if(got_nodes != numnodes)
+                return -1;
+        return got_nodes;
+}
 
 int main(int argc, char **argv)
 {
@@ -28,10 +46,14 @@ int main(int argc, char **argv)
 
 	pagesize = getpagesize();
 
-	nr_nodes = numa_max_node() + 1;
+	nr_nodes = get_node_list();
 
 	if (nr_nodes < 2) {
 		printf("A minimum of 2 nodes is required for this test.\n");
+		exit(1);
+	}
+	if (nr_nodes == -1) {
+		printf("Mismatch between congfigured nodes and memory-rich nodes.\n");
 		exit(1);
 	}
 
@@ -58,7 +80,7 @@ int main(int argc, char **argv)
 			/* We leave page 2 unallocated */
 			pages[ i * pagesize ] = (char) i;
 		addr[i] = pages + i * pagesize;
-		nodes[i] = (i % nr_nodes);
+		nodes[i] = node_to_use[(i % nr_nodes)];
 		status[i] = -123;
 	}
 
@@ -82,7 +104,7 @@ int main(int argc, char **argv)
 		if (i != 2) {
 			if (pages[ i* pagesize ] != (char) i)
 				errors++;
-			else if (nodes[i] != (i % nr_nodes))
+			else if (nodes[i] != node_to_use[(i % nr_nodes)])
 				errors++;
 		}
 	}


### PR DESCRIPTION
Patch fixes move_pages test for non-contiguous memory nodes and distributed pages among existing memory nodes instead of assuming continuous node IDs.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>