### PR TITLE
Fix: Add ShmemHugePages and ShmemPmdMapped to system_meminfo[]

### DIFF
--- a/numastat.c
+++ b/numastat.c
@@ -122,9 +122,11 @@ meminfo_t system_meminfo[] = {
 	{ 27, "SReclaimable", "SReclaimable" },
 	{ 28, "SUnreclaim", "SUnreclaim" },
 	{ 29, "AnonHugePages", "AnonHugePages" },
-	{ 30, "HugePages_Total", "HugePages_Total" },
-	{ 31, "HugePages_Free", "HugePages_Free" },
-	{ 32, "HugePages_Surp", "HugePages_Surp" }
+	{ 30, "ShmemHugePages", "ShmemHugePages" },
+	{ 31, "ShmemPmdMapped", "ShmemPmdMapped" },
+	{ 32, "HugePages_Total", "HugePages_Total" },
+	{ 33, "HugePages_Free", "HugePages_Free" },
+	{ 34, "HugePages_Surp", "HugePages_Surp" }
 };
 
 #define SYSTEM_MEMINFO_ROWS (sizeof(system_meminfo) / sizeof(system_meminfo[0]))


### PR DESCRIPTION
ShmemHugePages and ShmemPmdMapped were recently added to
/sys/devices/system/node/node*/meminfo. Adding entries for them in the
system_meminfo data structure got rid of the error "Token Node not in hash
table."

Signed-off-by: Sanskriti Sharma <sansharm@redhat.com>