### PR TITLE
Add missing MPOL_LOCAL policy in numaif.h

### DIFF
--- a/numaif.h
+++ b/numaif.h
@@ -26,9 +26,12 @@ extern long move_pages(int pid, unsigned long count,
 #define MPOL_PREFERRED   1
 #define MPOL_BIND        2
 #define MPOL_INTERLEAVE  3
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 #define MPOL_LOCAL       4
-
-#define MPOL_MAX MPOL_INTERLEAVE
+#define MPOL_MAX         5
+#else
+#define MPOL_MAX         4
+#endif
 
 /* Flags for get_mem_policy */
 #define MPOL_F_NODE    (1<<0)   /* return next il node or node of address */

--- a/numaif.h
+++ b/numaif.h
@@ -1,8 +1,6 @@
 #ifndef NUMAIF_H
 #define NUMAIF_H 1
 
-#include <linux/version.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -28,12 +26,8 @@ extern long move_pages(int pid, unsigned long count,
 #define MPOL_PREFERRED   1
 #define MPOL_BIND        2
 #define MPOL_INTERLEAVE  3
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 8, 0)
 #define MPOL_LOCAL       4
 #define MPOL_MAX         5
-#else
-#define MPOL_MAX         4
-#endif
 
 /* Flags for get_mem_policy */
 #define MPOL_F_NODE    (1<<0)   /* return next il node or node of address */

--- a/numaif.h
+++ b/numaif.h
@@ -1,6 +1,8 @@
 #ifndef NUMAIF_H
 #define NUMAIF_H 1
 
+#include <linux/version.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/numaif.h
+++ b/numaif.h
@@ -23,9 +23,10 @@ extern long move_pages(int pid, unsigned long count,
 
 /* Policies */
 #define MPOL_DEFAULT     0
-#define MPOL_PREFERRED    1
+#define MPOL_PREFERRED   1
 #define MPOL_BIND        2
 #define MPOL_INTERLEAVE  3
+#define MPOL_LOCAL       4
 
 #define MPOL_MAX MPOL_INTERLEAVE
 

--- a/test/randmap.c
+++ b/test/randmap.c
@@ -105,7 +105,7 @@ void testmap(void)
 
 	for (;;) {
 		unsigned long offset = random() % PAGES;
-		int policy = random() % (MPOL_MAX+1);
+		int policy = random() % (MPOL_MAX);
 		unsigned long nodes = random() % 4;
 		long length = random() % (PAGES - offset);
 


### PR DESCRIPTION
`MPOL_LOCAL` has been a policy since Linux 3.8, but is missing from `numaif.h`.

- Add missing `MPOL_LOCAL` policy to `numaif.h`
- `MPOL_MAX` now matches the Linux kernel (should be one greater than any other policy)

This is a minor but breaking change for applications that have defined `MPOL_LOCAL` themselves without checking if already defined.

Fixes #38 