### PR TITLE
numactl: add va_end to usage function

### DIFF
--- a/numactl.c
+++ b/numactl.c
@@ -101,6 +101,7 @@ void usage_msg(char *msg, ...)
 	vfprintf(stderr, msg, ap);
 	putchar('\n');
 	usage();
+	va_end(ap);
 }
 
 void show_physcpubind(void)


### PR DESCRIPTION
Fixes the following cppcheck:

  [numactl.c:104]: (error) va_list 'ap' was opened but not closed by va_end().

Signed-off-by: Sanskriti Sharma <sansharm@redhat.com>