### PR TITLE
Valgrind memory leak fixes

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -103,6 +103,8 @@ numa_init(void)
 	memset(&numa_no_nodes, 0, sizeof(numa_no_nodes));
 }
 
+static void cleanup_node_cpu_mask_v2();
+
 #define FREE_AND_ZERO(x) if (x) {	\
 		numa_bitmask_free(x);	\
 		x = NULL;		\
@@ -118,6 +120,7 @@ numa_fini(void)
 	FREE_AND_ZERO(numa_no_nodes_ptr);
 	FREE_AND_ZERO(numa_memnode_ptr);
 	FREE_AND_ZERO(numa_nodes_ptr);
+	cleanup_node_cpu_mask_v2();
 }
 
 /*
@@ -1246,6 +1249,20 @@ static init_node_cpu_mask_v2(void)
 {
 	int nnodes = numa_max_possible_node_v2_int() + 1;
 	node_cpu_mask_v2 = calloc (nnodes, sizeof(struct bitmask *));
+}
+
+static void cleanup_node_cpu_mask_v2(void)
+{
+	if (node_cpu_mask_v2) {
+		int i;
+		int nnodes;
+		nnodes = numa_max_possible_node_v2_int() + 1;
+		for (i = 0; i < nnodes; i++) {
+			FREE_AND_ZERO(node_cpu_mask_v2[i]);
+		}
+		free(node_cpu_mask_v2);
+		node_cpu_mask_v2 = NULL;
+	}
 }
 
 /* This would be better with some locking, but I don't want to make libnuma

--- a/numademo.c
+++ b/numademo.c
@@ -575,5 +575,6 @@ int main(int ac, char **av)
 			}
 		}
 	}
+	free(node_to_use);
 	return 0;
 }

--- a/numademo.c
+++ b/numademo.c
@@ -393,6 +393,8 @@ void test(enum test type)
 		printf("current interleave node %d\n", numa_get_interleave_node());
 	}
 
+	numa_bitmask_free(nodes);
+
 	numa_set_interleave_mask(numa_no_nodes_ptr);
 
 	nodes = numa_allocate_nodemask();
@@ -447,7 +449,7 @@ void test(enum test type)
 		if (!delim[0])
 			printf("\n\n\n");
 	}
-
+	numa_bitmask_free(nodes);
 	/* numa_run_on_node_mask is not tested */
 }
 


### PR DESCRIPTION
Fixes valgrind warnings when running:
```
valgrind --leak-check=full --show-leak-kinds=all .libs/numademo -t -e 1M
```