### PR TITLE
Enable building on s390x

### DIFF
--- a/distance.c
+++ b/distance.c
@@ -111,7 +111,7 @@ int numa_distance(int a, int b)
 {
 	if (!distance_table) {
 		int err = read_distance_table();
-		if (err < 0)
+		if ((err < 0) || (!distance_table))
 			return 0;
 	}
 	if ((unsigned)a >= distance_numnodes || (unsigned)b >= distance_numnodes)

--- a/syscall.c
+++ b/syscall.c
@@ -113,6 +113,14 @@
 /* https://bugs.debian.org/796802 */
 #warning "ARM does not implement the migrate_pages() syscall"
 
+#elif defined(__s390x__)
+
+#define __NR_mbind 235
+#define __NR_get_mempolicy 236
+#define __NR_set_mempolicy 237
+#define __NR_migrate_pages 238
+#define __NR_move_pages    239
+
 #elif !defined(DEPS_RUN)
 #error "Add syscalls for your architecture or update kernel headers"
 #endif

--- a/test/bind_range
+++ b/test/bind_range
@@ -91,7 +91,12 @@ function reset_mask
 	#echo -e "\taffinity of shell was reset to" $old_mask
 }
 
-HIGHESTCPU=$(grep 'processor' /proc/cpuinfo | tail -n1 | cut -f2 -d':')
+ARCH=`uname -m`
+if [ ${ARCH} != "s390x" ]; then
+	HIGHESTCPU=$(grep 'processor' /proc/cpuinfo | tail -n1 | cut -f2 -d':')
+else
+	HIGHESTCPU=$(grep 'processor' /proc/cpuinfo | tail -n1 | cut -f2 | sed 's/://' )
+fi
 HIGHESTCPU=$(echo $HIGHESTCPU | cut -f2 -d' ')
 HIGHESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus' | tail -n1 | cut -f2 -d' ')
 LOWESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus' | head -n1 | cut -f2 -d' ')


### PR DESCRIPTION
This patch enables building on Linux for s390x (aka Z aka Mainframe):

* ```syscall.c``` : Add syscalls ```__NR_mind->__NR_move_pages``` = 235-239
* ```distance.c``` : ```read_distance``` will return if there is no node directory in sysfs so this needs to be checked before trying to use this table in ```numa_distance()``` 
* ```test/bind_range``` : The format of ```/proc/cpuinfo``` is different for s390x so parsing the highest and lowest processor ids will not work as is
```
vendor_id       : IBM/S390
# processors    : 2
bogomips per cpu: 20325.00
max thread id   : 0
features	: esan3 zarch stfle msa ldisp eimm dfp etf3eh highgprs vx sie 
facilities      : 0 1 2 3 4 6 7 9 10 12 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 30 31 32 33 34 35 36 37 40 41 42 43 44 45 46 47 48 49 50 51 52 53 55 57 74 75 76 77 80 81 82 128 129 1024 1025 1026 1027 1028 1030 1031 1033 1034 1036 1038 1039 1040 1041 1042 1043 1044 1045 1046 1047 1048 1049 1050 1051 1052 1054 1055 1056 1057 1058 1059 1060 1061 1064 1065 1066 1067 1068 1069 1070 1071 1072 1073 1074 1075 1076 1077 1079 1081 1098 1099 1100 1101 1104 1105 1152 1153
cache0          : level=1 type=Data scope=Private size=128K line_size=256 associativity=8
cache1          : level=1 type=Instruction scope=Private size=96K line_size=256 associativity=6
cache2          : level=2 type=Data scope=Private size=2048K line_size=256 associativity=8
cache3          : level=2 type=Instruction scope=Private size=2048K line_size=256 associativity=8
cache4          : level=3 type=Unified scope=Shared size=65536K line_size=256 associativity=16
cache5          : level=4 type=Unified scope=Shared size=491520K line_size=256 associativity=30
processor 0: version = FF,  identification = 010000,  machine = 2964
processor 1: version = FF,  identification = 020000,  machine = 2964
```

The motivation for this patch is that packages like ```openvswitch``` now expect ```numactl``` to be available.