### PR TITLE
update numastat to match upstream Linux

### DIFF
--- a/numastat.c
+++ b/numastat.c
@@ -824,7 +824,7 @@ void show_info_from_system_file(char *file, meminfo_p meminfo, int meminfo_rows,
 			// example line from meminfo  file: "Node 3 Inactive:  210680 kB"
 			int index = hash_lookup(tok[0 + tok_offset]);
 			if (index < 0) {
-				printf("Token %s not in hash table.\n", tok[0]);
+				printf("Token %s not in hash table.\n", tok[0 + tok_offset]);
 			} else {
 				double value = (double)atol(tok[1 + tok_offset]);
 				if (!compatibility_mode) {

--- a/numastat.c
+++ b/numastat.c
@@ -126,7 +126,8 @@ meminfo_t system_meminfo[] = {
 	{ 31, "ShmemPmdMapped", "ShmemPmdMapped" },
 	{ 32, "HugePages_Total", "HugePages_Total" },
 	{ 33, "HugePages_Free", "HugePages_Free" },
-	{ 34, "HugePages_Surp", "HugePages_Surp" }
+	{ 34, "HugePages_Surp", "HugePages_Surp" },
+	{ 35, "KReclaimable", "KReclaimable" }
 };
 
 #define SYSTEM_MEMINFO_ROWS (sizeof(system_meminfo) / sizeof(system_meminfo[0]))


### PR DESCRIPTION
The meminfo file sprouted a new data item "KReclaimable" in v4.20. Update the list in numastat. Also (separate commit) fix the diagnostic message printed when unknown fields are found.