### PR TITLE
numastat: when reading no-exist pid, return EXIT_FAILURE

### DIFF
--- a/numastat.c
+++ b/numastat.c
@@ -1023,6 +1023,7 @@ void show_process_info() {
 		if (ferror(fs)) {
 			sprintf(buf, "Can't read /proc/%d/numa_maps", pid);
 			perror(buf);
+			exit(EXIT_FAILURE);
 		}
 		fclose(fs);
 		// If showing individual tables, or we just added the last total line,


### PR DESCRIPTION
This ease the result query by bash $?

Signed-off-by: Pingfan Liu <piliu@redhat.com>