### PR TITLE
numastat.8: clarify that information relates to resident pages

### DIFF
--- a/numastat.8
+++ b/numastat.8
@@ -54,6 +54,8 @@ Any supplied options or arguments with the \fBnumastat\fP command will
 significantly change both the content and the format of the display.  Specified
 options will cause display units to change to megabytes of memory, and will
 change other specific behaviors of \fBnumastat\fP as described below.
+.LP
+Memory usage information reflects the resident pages on the system.
 .SH "OPTIONS"
 .LP
 .TP


### PR DESCRIPTION
The man page gives no hint about whether memory usage information
relates to resident pages or virtual memory.  The answer may not be
obvious to the user, so explicitly mention that only resident pages are
counted.

Suggested-by: Daniele Palumbo <daniele@retaggio.net>
Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>