### PR TITLE
Handle cpu-less node for bind_range test

### DIFF
--- a/test/bind_range
+++ b/test/bind_range
@@ -98,8 +98,8 @@ else
 	HIGHESTCPU=$(grep 'processor' /proc/cpuinfo | tail -n1 | cut -f2 | sed 's/://' )
 fi
 HIGHESTCPU=$(echo $HIGHESTCPU | cut -f2 -d' ')
-HIGHESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus' | tail -n1 | cut -f2 -d' ')
-LOWESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus' | head -n1 | cut -f2 -d' ')
+HIGHESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus: [0-9]*' | tail -n1 | cut -f2 -d' ')
+LOWESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus: [0-9]*' | head -n1 | cut -f2 -d' ')
 
 get_mask
 


### PR DESCRIPTION
Patch handles cpu-less nodes by selecting nodes with cpus to be used for binding

Ex.
node 8 cpus : 8 9 10 11
node 255 cpus:

Signed-off-by: Harish <harish@linux.vnet.ibm.com>