### PR TITLE
libnuma: introduce an API to outdate cpu to node mapping

### DIFF
--- a/numa.3
+++ b/numa.3
@@ -124,6 +124,8 @@ numa \- NUMA policy library
 .br
 .BI "int numa_node_to_cpus(int " node ", struct bitmask *" mask ");
 .br
+.BI "void numa_node_to_cpu_update();"
+.br
 .BI "int numa_node_of_cpu(int " cpu ");
 .sp
 .BI "struct bitmask *numa_allocate_cpumask();"
@@ -232,6 +234,7 @@ Most functions in this library are only concerned about numa nodes and
 their memory.
 The exceptions to this are:
 .IR numa_node_to_cpus (),
+.IR numa_node_to_cpu_update (),
 .IR numa_node_of_cpu (),
 .IR numa_bind (),
 .IR numa_run_on_node (),
@@ -794,6 +797,10 @@ Use numa_allocate_cpumask() to create it.  If the bitmask is not long enough
 will be set to
 .I ERANGE
 and \-1 returned. On success 0 is returned.
+
+.BR numa_node_to_cpu_update ()
+Mark the node's cpus bitmask stale, then get the latest bitmask by calling
+.BR numa_node_to_cpus ()
 
 .BR numa_node_of_cpu ()
 returns the node that a cpu belongs to. If the user supplies an invalid cpu

--- a/numa.h
+++ b/numa.h
@@ -282,6 +282,8 @@ static inline void numa_free_cpumask(struct bitmask *b)
 /* Convert node to CPU mask. -1/errno on failure, otherwise 0. */
 int numa_node_to_cpus(int, struct bitmask *);
 
+void numa_node_to_cpu_update(void);
+
 /* report the node of the specified cpu. -1/errno on invalid cpu. */
 int numa_node_of_cpu(int cpu);
 

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -60,6 +60,7 @@ libnuma_1.1 {
     numa_tonodemask_memory;
     numa_warn;
     numa_exit_on_warn;
+    numa_node_to_cpu_update;
   local:
     *;
 };


### PR DESCRIPTION
numa_node_to_cpus() caches the cpu to node mapping, and not updates it
during the cpu online/offline event.

Ideally, in order to update the mapping automatically, it requires
something like udev to spy on kernel event socket, and update cache if
event happen. This solution is a little complicated inside a libnuma.so. In
stead of doing so, exposing an API numa_node_to_cpu_outdated() for user,
and saddling the event-detecting task to the user.

So the user of libnuma can work using either of the following models:
 -1. blindless outdate cache if careless about performance
     numa_node_to_cpu_outdated();
     numa_node_to_cpu();
 -2. event driven spy on kernel event, if happened, call
     numa_node_to_cpu_outdated();

Signed-off-by: Pingfan Liu <piliu@redhat.com>