### PR TITLE
Skip `test/move_pages` if we don't have at least two nodes available

### DIFF
--- a/test/move_pages.c
+++ b/test/move_pages.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
 
 	if (nr_nodes < 2) {
 		printf("A minimum of 2 nodes is required for this test.\n");
-		exit(1);
+		exit(77);
 	}
 	if (nr_nodes == -1) {
 		printf("Mismatch between congfigured nodes and memory-rich nodes.\n");


### PR DESCRIPTION
If hardware that doesn't support this test is not available, we should SKIP rather than FAIL.

This is akin to what we've done with `test/regress` in commit 4042d9e20f755f.