### PR TITLE
numademo: fix incompatible pointer types

### DIFF
--- a/test/move_pages.c
+++ b/test/move_pages.c
@@ -26,7 +26,7 @@ int *node_to_use;
 int get_node_list()
 {
         int a, got_nodes = 0, max_node, numnodes;
-        long free_node_sizes;
+        long long free_node_sizes;
 
         numnodes = numa_num_configured_nodes();
         node_to_use = (int *)malloc(numnodes * sizeof(int));


### PR DESCRIPTION
a7c4bc7 introduced a error about incompatible pointer types.

test/move_pages.c:35:39: error: passing argument 2 of
'numa_node_size' from incompatible pointer type
[-Werror=incompatible-pointer-types]
    if (numa_node_size(a, &free_node_sizes) > 0)
                                          ^^
Unified variable type and fix it.

Signed-off-by: Hongzhi.Song <hongzhi.song@windriver.com>