### PR TITLE
shm: exit when ftruncate() fails

### DIFF
--- a/shm.c
+++ b/shm.c
@@ -151,6 +151,7 @@ void attach_shared(char *name, char *opt)
 			   would be impossible to apply policy then.
 			   need to fix that in the kernel. */
 			perror("ftruncate");
+			exit(1);
 		}
 	}
 


### PR DESCRIPTION
numa_police_memory() accesses the mapping region, which size is shmlen.
If the shared file can not be extended to shmlen, then SIGBUS will be
triggered. Instead exit() is more graceful.

Signed-off-by: Pingfan Liu <piliu@redhat.com>