### PR TITLE
numastat: add an option to print information on how a file is cached

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ numactl_LDADD = libnuma.la
 
 numastat_SOURCES = numastat.c
 numastat_CFLAGS = $(AM_CFLAGS) -std=gnu99
+numastat_LDADD = libnuma.la
 
 numademo_SOURCES = numademo.c stream_lib.c stream_lib.h mt.c mt.h clearcache.c clearcache.h
 numademo_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_STREAM_LIB -DHAVE_MT -DHAVE_CLEAR_CACHE


### PR DESCRIPTION
This patch introduces the "-f" option to numastat, it provides similar
information to the existing FilePages field, but for a single file.

This feature can prove useful for debugging performance issues on
systems with many NUMA nodes. If a large file is cached exclusively on
a single NUMA node this can create an interconnect bottleneck when
all CPUs access this file simultaneously.

Here is an example output:
```
$ numastat -c -f /tmp/myfile

Per-node page cache info for file /tmp/myfile (in MiB):
           Node 0 Node 1 Node 2 Node 3 Total
           ------ ------ ------ ------ -----
FilePages       0      0   3199   3199  6397
```

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>