### PR TITLE
Use symver attribute not asms for symbol versioning.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: c
 
 env:
@@ -6,6 +7,22 @@ env:
 
 matrix:
   include:
+    - name: "gcc 10"
+      env: MATRIX_ENV="CC=gcc-10 CXX=g++-10"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-10
+    - name: "gcc 9"
+      env: MATRIX_ENV="CC=gcc-9 CXX=g++-9"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-9
     - name: "gcc 8"
       env: MATRIX_ENV="CC=gcc-8 CXX=g++-8"
       addons:
@@ -31,6 +48,7 @@ matrix:
           packages:
             - gcc-6
     - name: "gcc 5"
+      dist: xenial
       env: MATRIX_ENV="CC=gcc-5 CXX=g++-5"
       addons:
         apt:
@@ -39,6 +57,7 @@ matrix:
           packages:
             - gcc-5
     - name: "gcc 4.9"
+      dist: xenial
       env: MATRIX_ENV="CC=gcc-4.9 CXX=g++-4.9"
       addons:
         apt:

--- a/configure.ac
+++ b/configure.ac
@@ -24,4 +24,12 @@ AM_CONDITIONAL([HAVE_TREE_VECTORIZE], [test x"${tree_vectorize}" = x"true"])
 
 AC_CONFIG_FILES([Makefile])
 
+# GCC tries to be "helpful" and only issue a warning for unrecognized
+# attributes.  So we compile the test with Werror, so that if the
+# attribute is not recognized the compilation fails
+AC_LANG(C)
+AC_LANG_WERROR
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[__attribute__ ((symver ("foo@foo_1"))) void frob (void) { }]])],
+                  [AC_DEFINE([HAVE_ATTRIBUTE_SYMVER], [1], [Checking for symver attribute])], [])
+
 AC_OUTPUT

--- a/libnuma.c
+++ b/libnuma.c
@@ -688,19 +688,19 @@ make_internal_alias(numa_max_node);
  * which for v1 is the size of a numa.h nodemask_t(in bits)-1.
  * but for v2 is the size of a kernel nodemask_t(in bits)-1.
  */
+SYMVER("numa_max_possible_node_v1", "numa_max_possible_node@libnuma_1.1")
 int
 numa_max_possible_node_v1(void)
 {
 	return ((sizeof(nodemask_t)*8)-1);
 }
-__asm__(".symver numa_max_possible_node_v1,numa_max_possible_node@libnuma_1.1");
 
+SYMVER("numa_max_possible_node_v2", "numa_max_possible_node@@libnuma_1.2")
 int
 numa_max_possible_node_v2(void)
 {
 	return numa_num_possible_nodes()-1;
 }
-__asm__(".symver numa_max_possible_node_v2,numa_max_possible_node@@libnuma_1.2");
 
 make_internal_alias(numa_max_possible_node_v1);
 make_internal_alias(numa_max_possible_node_v2);
@@ -809,6 +809,7 @@ int numa_available(void)
 	return 0;
 }
 
+SYMVER("numa_interleave_memory_v1", "numa_interleave_memory@libnuma_1.1")
 void
 numa_interleave_memory_v1(void *mem, size_t size, const nodemask_t *mask)
 {
@@ -818,14 +819,13 @@ numa_interleave_memory_v1(void *mem, size_t size, const nodemask_t *mask)
 	bitmask.maskp = (unsigned long *)mask;
 	dombind(mem, size, MPOL_INTERLEAVE, &bitmask);
 }
-__asm__(".symver numa_interleave_memory_v1,numa_interleave_memory@libnuma_1.1");
 
+SYMVER("numa_interleave_memory_v2", "numa_interleave_memory@@libnuma_1.2")
 void
 numa_interleave_memory_v2(void *mem, size_t size, struct bitmask *bmp)
 {
 	dombind(mem, size, MPOL_INTERLEAVE, bmp);
 }
-__asm__(".symver numa_interleave_memory_v2,numa_interleave_memory@@libnuma_1.2");
 
 void numa_tonode_memory(void *mem, size_t size, int node)
 {
@@ -837,6 +837,7 @@ void numa_tonode_memory(void *mem, size_t size, int node)
 	numa_bitmask_free(nodes);
 }
 
+SYMVER("numa_tonodemask_memory_v1", "numa_tonodemask_memory@libnuma_1.1")
 void
 numa_tonodemask_memory_v1(void *mem, size_t size, const nodemask_t *mask)
 {
@@ -846,14 +847,13 @@ numa_tonodemask_memory_v1(void *mem, size_t size, const nodemask_t *mask)
 	bitmask.size  = sizeof(nodemask_t);
 	dombind(mem, size,  bind_policy, &bitmask);
 }
-__asm__(".symver numa_tonodemask_memory_v1,numa_tonodemask_memory@libnuma_1.1");
 
+SYMVER("numa_tonodemask_memory_v2", "numa_tonodemask_memory@@libnuma_1.2")
 void
 numa_tonodemask_memory_v2(void *mem, size_t size, struct bitmask *bmp)
 {
 	dombind(mem, size,  bind_policy, bmp);
 }
-__asm__(".symver numa_tonodemask_memory_v2,numa_tonodemask_memory@@libnuma_1.2");
 
 void numa_setlocal_memory(void *mem, size_t size)
 {
@@ -898,6 +898,7 @@ void *numa_realloc(void *old_addr, size_t old_size, size_t new_size)
 	return mem;
 }
 
+SYMVER("numa_alloc_interleaved_subset_v1", "numa_alloc_interleaved_subset@libnuma_1.1")
 void *numa_alloc_interleaved_subset_v1(size_t size, const nodemask_t *mask)
 {
 	char *mem;
@@ -912,8 +913,8 @@ void *numa_alloc_interleaved_subset_v1(size_t size, const nodemask_t *mask)
 	dombind(mem, size, MPOL_INTERLEAVE, &bitmask);
 	return mem;
 }
-__asm__(".symver numa_alloc_interleaved_subset_v1,numa_alloc_interleaved_subset@libnuma_1.1");
 
+SYMVER("numa_alloc_interleaved_subset_v2", "numa_alloc_interleaved_subset@@libnuma_1.2")
 void *numa_alloc_interleaved_subset_v2(size_t size, struct bitmask *bmp)
 {
 	char *mem;
@@ -925,7 +926,6 @@ void *numa_alloc_interleaved_subset_v2(size_t size, struct bitmask *bmp)
 	dombind(mem, size, MPOL_INTERLEAVE, bmp);
 	return mem;
 }
-__asm__(".symver numa_alloc_interleaved_subset_v2,numa_alloc_interleaved_subset@@libnuma_1.2");
 
 make_internal_alias(numa_alloc_interleaved_subset_v1);
 make_internal_alias(numa_alloc_interleaved_subset_v2);
@@ -939,6 +939,7 @@ numa_alloc_interleaved(size_t size)
 /*
  * given a user node mask, set memory policy to use those nodes
  */
+SYMVER("numa_set_interleave_mask_v1", "numa_set_interleave_mask@libnuma_1.1")
 void
 numa_set_interleave_mask_v1(nodemask_t *mask)
 {
@@ -954,8 +955,8 @@ numa_set_interleave_mask_v1(nodemask_t *mask)
 	numa_bitmask_free(bmp);
 }
 
-__asm__(".symver numa_set_interleave_mask_v1,numa_set_interleave_mask@libnuma_1.1");
 
+SYMVER("numa_set_interleave_mask_v2", "numa_set_interleave_mask@@libnuma_1.2")
 void
 numa_set_interleave_mask_v2(struct bitmask *bmp)
 {
@@ -964,8 +965,8 @@ numa_set_interleave_mask_v2(struct bitmask *bmp)
 	else
 		setpol(MPOL_INTERLEAVE, bmp);
 }
-__asm__(".symver numa_set_interleave_mask_v2,numa_set_interleave_mask@@libnuma_1.2");
 
+SYMVER("numa_get_interleave_mask_v1", "numa_get_interleave_mask@libnuma_1.1")
 nodemask_t
 numa_get_interleave_mask_v1(void)
 {
@@ -982,8 +983,8 @@ numa_get_interleave_mask_v1(void)
 	numa_bitmask_free(bmp);
 	return mask;
 }
-__asm__(".symver numa_get_interleave_mask_v1,numa_get_interleave_mask@libnuma_1.1");
 
+SYMVER("numa_get_interleave_mask_v2", "numa_get_interleave_mask@@libnuma_1.2")
 struct bitmask *
 numa_get_interleave_mask_v2(void)
 {
@@ -996,7 +997,6 @@ numa_get_interleave_mask_v2(void)
 		copy_bitmask_to_bitmask(numa_no_nodes_ptr, bmp);
 	return bmp;
 }
-__asm__(".symver numa_get_interleave_mask_v2,numa_get_interleave_mask@@libnuma_1.2");
 
 /* (undocumented) */
 int numa_get_interleave_node(void)
@@ -1044,6 +1044,7 @@ void numa_set_bind_policy(int strict)
 		bind_policy = MPOL_PREFERRED;
 }
 
+SYMVER("numa_set_membind_v1", "numa_set_membind@libnuma_1.1")
 void
 numa_set_membind_v1(const nodemask_t *mask)
 {
@@ -1053,14 +1054,13 @@ numa_set_membind_v1(const nodemask_t *mask)
 	bitmask.size  = sizeof(nodemask_t);
 	setpol(MPOL_BIND, &bitmask);
 }
-__asm__(".symver numa_set_membind_v1,numa_set_membind@libnuma_1.1");
 
+SYMVER("numa_set_membind_v2", "numa_set_membind@@libnuma_1.2")
 void
 numa_set_membind_v2(struct bitmask *bmp)
 {
 	setpol(MPOL_BIND, bmp);
 }
-__asm__(".symver numa_set_membind_v2,numa_set_membind@@libnuma_1.2");
 
 make_internal_alias(numa_set_membind_v2);
 
@@ -1119,6 +1119,7 @@ copy_nodemask_to_bitmask(nodemask_t *nmp, struct bitmask *bmp)
 	}
 }
 
+SYMVER("numa_get_membind_v1", "numa_get_membind@libnuma_1.1")
 nodemask_t
 numa_get_membind_v1(void)
 {
@@ -1138,8 +1139,8 @@ numa_get_membind_v1(void)
 	numa_bitmask_free(bmp);
 	return nmp;
 }
-__asm__(".symver numa_get_membind_v1,numa_get_membind@libnuma_1.1");
 
+SYMVER("numa_get_membind_v2", "numa_get_membind@@libnuma_1.2")
 struct bitmask *
 numa_get_membind_v2(void)
 {
@@ -1152,7 +1153,6 @@ numa_get_membind_v2(void)
 		copy_bitmask_to_bitmask(numa_all_nodes_ptr, bmp);
 	return bmp;
 }
-__asm__(".symver numa_get_membind_v2,numa_get_membind@@libnuma_1.2");
 
 //TODO:  do we need a v1 nodemask_t version?
 struct bitmask *numa_get_mems_allowed(void)
@@ -1175,6 +1175,7 @@ void numa_free(void *mem, size_t size)
 	munmap(mem, size);
 }
 
+SYMVER("numa_parse_bitmap_v1", "numa_parse_bitmap@libnuma_1.1")
 int
 numa_parse_bitmap_v1(char *line, unsigned long *mask, int ncpus)
 {
@@ -1208,8 +1209,8 @@ numa_parse_bitmap_v1(char *line, unsigned long *mask, int ncpus)
 	}
 	return 0;
 }
-__asm__(".symver numa_parse_bitmap_v1,numa_parse_bitmap@libnuma_1.1");
 
+SYMVER("numa_parse_bitmap_v2", "numa_parse_bitmap@@libnuma_1.2")
 int
 numa_parse_bitmap_v2(char *line, struct bitmask *mask)
 {
@@ -1244,7 +1245,6 @@ numa_parse_bitmap_v2(char *line, struct bitmask *mask)
 	}
 	return 0;
 }
-__asm__(".symver numa_parse_bitmap_v2,numa_parse_bitmap@@libnuma_1.2");
 
 static void init_node_cpu_mask_v2(void)
 {
@@ -1268,6 +1268,7 @@ static void cleanup_node_cpu_mask_v2(void)
 
 /* This would be better with some locking, but I don't want to make libnuma
    dependent on pthreads right now. The races are relatively harmless. */
+SYMVER("numa_node_to_cpus_v1", "numa_node_to_cpus@libnuma_1.1")
 int
 numa_node_to_cpus_v1(int node, unsigned long *buffer, int bufferlen)
 {
@@ -1347,7 +1348,6 @@ numa_node_to_cpus_v1(int node, unsigned long *buffer, int bufferlen)
 	}
 	return err;
 }
-__asm__(".symver numa_node_to_cpus_v1,numa_node_to_cpus@libnuma_1.1");
 
 /*
  * test whether a node has cpus
@@ -1357,6 +1357,7 @@ __asm__(".symver numa_node_to_cpus_v1,numa_node_to_cpus@libnuma_1.1");
 /*
  * deliver a bitmask of cpus representing the cpus on a given node
  */
+SYMVER("numa_node_to_cpus_v2", "numa_node_to_cpus@@libnuma_1.2")
 int
 numa_node_to_cpus_v2(int node, struct bitmask *buffer)
 {
@@ -1437,7 +1438,6 @@ numa_node_to_cpus_v2(int node, struct bitmask *buffer)
 	}
 	return err;
 }
-__asm__(".symver numa_node_to_cpus_v2,numa_node_to_cpus@@libnuma_1.2");
 
 make_internal_alias(numa_node_to_cpus_v1);
 make_internal_alias(numa_node_to_cpus_v2);
@@ -1478,6 +1478,7 @@ end:
 	return ret;
 }
 
+SYMVER("numa_run_on_node_mask_v1", "numa_run_on_node_mask@libnuma_1.1")
 int
 numa_run_on_node_mask_v1(const nodemask_t *mask)
 {
@@ -1530,13 +1531,13 @@ numa_run_on_node_mask_v1(const nodemask_t *mask)
 	}
 	return err;
 }
-__asm__(".symver numa_run_on_node_mask_v1,numa_run_on_node_mask@libnuma_1.1");
 
 /*
  * Given a node mask (size of a kernel nodemask_t) (probably populated by
  * a user argument list) set up a map of cpus (map "cpus") on those nodes.
  * Then set affinity to those cpus.
  */
+SYMVER("numa_run_on_node_mask_v2", "numa_run_on_node_mask@@libnuma_1.2")
 int
 numa_run_on_node_mask_v2(struct bitmask *bmp)
 {
@@ -1581,7 +1582,6 @@ numa_run_on_node_mask_v2(struct bitmask *bmp)
 
 	return err;
 }
-__asm__(".symver numa_run_on_node_mask_v2,numa_run_on_node_mask@@libnuma_1.2");
 
 make_internal_alias(numa_run_on_node_mask_v2);
 
@@ -1631,6 +1631,7 @@ numa_run_on_node_mask_all(struct bitmask *bmp)
 	return err;
 }
 
+SYMVER("numa_get_run_node_mask_v1", "numa_get_run_node_mask@libnuma_1.1")
 nodemask_t
 numa_get_run_node_mask_v1(void)
 {
@@ -1665,8 +1666,8 @@ free_cpus:
 	numa_bitmask_free(cpus);
 	return nmp;
 }
-__asm__(".symver numa_get_run_node_mask_v1,numa_get_run_node_mask@libnuma_1.1");
 
+SYMVER("numa_get_run_node_mask_v2", "numa_get_run_node_mask@@libnuma_1.2")
 struct bitmask *
 numa_get_run_node_mask_v2(void)
 {
@@ -1705,7 +1706,6 @@ free_cpus:
 	numa_bitmask_free(cpus);
 	return bmp;
 }
-__asm__(".symver numa_get_run_node_mask_v2,numa_get_run_node_mask@@libnuma_1.2");
 
 int
 numa_migrate_pages(int pid, struct bitmask *fromnodes, struct bitmask *tonodes)
@@ -1792,6 +1792,7 @@ void numa_set_localalloc(void)
 	setpol(MPOL_DEFAULT, numa_no_nodes_ptr);
 }
 
+SYMVER("numa_bind_v1", "numa_bind@libnuma_1.1")
 void numa_bind_v1(const nodemask_t *nodemask)
 {
 	struct bitmask bitmask;
@@ -1801,14 +1802,13 @@ void numa_bind_v1(const nodemask_t *nodemask)
 	numa_run_on_node_mask_v2_int(&bitmask);
 	numa_set_membind_v2_int(&bitmask);
 }
-__asm__(".symver numa_bind_v1,numa_bind@libnuma_1.1");
 
+SYMVER("numa_bind_v2", "numa_bind@@libnuma_1.2")
 void numa_bind_v2(struct bitmask *bmp)
 {
 	numa_run_on_node_mask_v2_int(bmp);
 	numa_set_membind_v2_int(bmp);
 }
-__asm__(".symver numa_bind_v2,numa_bind@@libnuma_1.2");
 
 void numa_set_strict(int flag)
 {

--- a/syscall.c
+++ b/syscall.c
@@ -20,6 +20,8 @@
 #include "numa.h"
 #include "numaif.h"
 #include "numaint.h"
+#include "config.h"
+#include "util.h"
 
 #define WEAK __attribute__((weak))
 
@@ -238,26 +240,27 @@ long WEAK move_pages(int pid, unsigned long count,
 }
 
 /* SLES8 glibc doesn't define those */
+SYMVER("numa_sched_setaffinity_v1", "numa_sched_setaffinity@libnuma_1.1")
 int numa_sched_setaffinity_v1(pid_t pid, unsigned len, const unsigned long *mask)
 {
 	return syscall(__NR_sched_setaffinity,pid,len,mask);
 }
-__asm__(".symver numa_sched_setaffinity_v1,numa_sched_setaffinity@libnuma_1.1");
 
+SYMVER("numa_sched_setaffinity_v2", "numa_sched_setaffinity@@libnuma_1.2")
 int numa_sched_setaffinity_v2(pid_t pid, struct bitmask *mask)
 {
 	return syscall(__NR_sched_setaffinity, pid, numa_bitmask_nbytes(mask),
 								mask->maskp);
 }
-__asm__(".symver numa_sched_setaffinity_v2,numa_sched_setaffinity@@libnuma_1.2");
 
+SYMVER("numa_sched_getaffinity_v1", "numa_sched_getaffinity@libnuma_1.1")
 int numa_sched_getaffinity_v1(pid_t pid, unsigned len, const unsigned long *mask)
 {
 	return syscall(__NR_sched_getaffinity,pid,len,mask);
 
 }
-__asm__(".symver numa_sched_getaffinity_v1,numa_sched_getaffinity@libnuma_1.1");
 
+SYMVER("numa_sched_getaffinity_v2", "numa_sched_getaffinity@@libnuma_1.2")
 int numa_sched_getaffinity_v2(pid_t pid, struct bitmask *mask)
 {
 	/* len is length in bytes */
@@ -266,7 +269,6 @@ int numa_sched_getaffinity_v2(pid_t pid, struct bitmask *mask)
 	/* sched_getaffinity returns sizeof(cpumask_t) */
 
 }
-__asm__(".symver numa_sched_getaffinity_v2,numa_sched_getaffinity@@libnuma_1.2");
 
 make_internal_alias(numa_sched_getaffinity_v1);
 make_internal_alias(numa_sched_getaffinity_v2);

--- a/util.h
+++ b/util.h
@@ -18,3 +18,9 @@ extern char *policy_name(int policy);
 #define array_len(x) (sizeof(x)/sizeof(*(x)))
 
 #define round_up(x,y) (((x) + (y) - 1) & ~((y)-1))
+
+#if HAVE_ATTRIBUTE_SYMVER
+#define SYMVER(a,b) __attribute__ ((symver (b)))
+#else
+#define SYMVER(a,b) __asm__ (".symver " #a "," #b);
+#endif


### PR DESCRIPTION
Originally proposed in https://src.fedoraproject.org/rpms/numactl/pull-request/3

Comment from Jeff Law:

> This package is currently opted out of LTO because it uses ASMs to implement symbol versioning. ASMs like this are fundamentally incompatible with LTO because GCC does not look inside the ASM string to find symbol references. Starting with gcc-10 there is a new symbol attribute for implementing symbol versioning. This patch changes numactl to use that symbol attribute and re-enables LTO. Note the patch includes a fallback to the old way of implementing symbol versioning via asms, so in theory it should work with clang as well as gcc-9 and earlier. I haven't fully tested the fallback path.
