### PR TITLE
Release numactl 2.0.14

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ numastat_CFLAGS = $(AM_CFLAGS) -std=gnu99
 
 numademo_SOURCES = numademo.c stream_lib.c stream_lib.h mt.c mt.h clearcache.c clearcache.h
 numademo_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_STREAM_LIB -DHAVE_MT -DHAVE_CLEAR_CACHE
-numademo_CFLAGS = -O3 -ffast-math -funroll-loops
+numademo_CFLAGS = $(AM_CFLAGS) -O3 -ffast-math -funroll-loops
 if HAVE_TREE_VECTORIZE
 numademo_CFLAGS += -ftree-vectorize
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,6 @@ migspeed_LDADD = libnuma.la -lrt
 memhog_SOURCES = memhog.c util.c
 memhog_LDADD = libnuma.la
 
-libnuma_la_CFLAGS = -g -O2 -fno-lto
 libnuma_la_SOURCES = libnuma.c syscall.c distance.c affinity.c affinity.h sysfs.c sysfs.h rtnetlink.c rtnetlink.h versions.ldscript
 libnuma_la_LDFLAGS = -version-info 1:0:0 -Wl,--version-script,$(srcdir)/versions.ldscript -Wl,-init,numa_init -Wl,-fini,numa_fini
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.64])
-AC_INIT([numactl], [2.0.13])
+AC_INIT([numactl], [2.0.14])
 
 AC_CONFIG_SRCDIR([numactl.c])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Pushing two more small commits related to LTO, follow ups for #92, then bumping the version on the `configure.ac` file.