### PR TITLE
test/bind_range: Handle memory-less nodes for cpubind

### DIFF
--- a/test/bind_range
+++ b/test/bind_range
@@ -98,8 +98,8 @@ else
 	HIGHESTCPU=$(grep 'processor' /proc/cpuinfo | tail -n1 | cut -f2 | sed 's/://' )
 fi
 HIGHESTCPU=$(echo $HIGHESTCPU | cut -f2 -d' ')
-HIGHESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus: [0-9]*' | tail -n1 | cut -f2 -d' ')
-LOWESTNODE=$(numactl -H | grep -e 'node [0-9]* cpus: [0-9]*' | head -n1 | cut -f2 -d' ')
+HIGHESTNODE=$(numactl -H | grep -Pzo 'node [0-9]* cpus: [0-9]* (.|\n)*node [0-9]* size: [1-9]* MB' | tail -n1 | cut -f2 -d' ')
+LOWESTNODE=$(numactl -H | grep -Pzo 'node [0-9]* cpus: [0-9]* (.|\n)*node [0-9]* size: [1-9]* MB' | head -n1 | cut -f2 -d' ')
 
 get_mask
 


### PR DESCRIPTION
This patch filters out numa nodes with more than 0 MB memory so that those nodes can be used for cpunodebind tests

eg.
node 17 cpus: 120 121 122 123 124 125 126 127 128 129 130 131
node 17 size: 0 MB
node 17 free: 0 MB

Signed-off-by: Harish <harish@linux.ibm.com>