### PR TITLE
numastat: add bash completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -160,3 +160,6 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = numa.pc
 EXTRA_DIST += numa.pc.in
 CLEANFILES += numa.pc
+
+bashcompdir = @bashcompdir@
+dist_bashcomp_DATA = numastat.bash

--- a/configure.ac
+++ b/configure.ac
@@ -32,4 +32,8 @@ AC_LANG_WERROR
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[__attribute__ ((symver ("foo@foo_1"))) void frob (void) { }]])],
                   [AC_DEFINE([HAVE_ATTRIBUTE_SYMVER], [1], [Checking for symver attribute])], [])
 
+PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], ,
+              bashcompdir="${sysconfdir}/bash_completion.d")
+AC_SUBST(bashcompdir)
+
 AC_OUTPUT

--- a/numactl.bash
+++ b/numactl.bash
@@ -1,0 +1,106 @@
+_numactl() {
+
+	local -v curr=${COMP_WORDS[COMP_CWORD]}
+	local -v prev=${COMP_WORDS[COMP_CWORD - 1]}
+
+	local -A command_opts=(
+		["--all"]=-a
+		["--interleave="]=-i
+		["--preferred="]=-p
+		["--physcpubind="]=-C
+		["--cpunodebind="]=-N
+		["--membind="]=-m
+		["--localalloc="]=-l
+	)
+	local -A show_opts=(
+		["--show"]=-s
+	)
+	local -A hardware_opts=(
+		["--hardware"]=-H
+	)
+	local -A policy_opts=(  # XXX ='s here
+		["--length="]=-l
+		["--offset="]=-o
+		["--shmmode="]=-M
+		["--strict"]=-t
+		["--shmid="]=-I
+		["--shm="]=-S
+		["--file="]=-f
+		["--huge"]=-u
+		["--touch"]=-T
+	)
+	local -A policy_actions=(
+		["--interleave"]=-i
+		["--preferred"]=-p
+		["--membind"]=-m
+		["--localalloc"]=-l
+	)
+
+	local -v i j word mode
+        for in ${!COMP_WORDS[@]}; do
+            word=${COMP_WORDS[i]}
+		for j in ${!show_opts[@]}; do
+			case $word in
+				$j | ${show_opts[j]})
+					mode=show
+					break 2
+					;;
+                                $j*)
+                                    if [[ $j == *= ]]; then
+					mode=show
+					break 2
+                                    fi
+			esac
+		done
+		for j in ${!hardware_opts[@]}; do
+			case $word in
+				$j | ${hardware_opts[j]})
+					mode=hardware
+					break 2
+					;;
+			esac
+		done
+		for j in ${!policy_opts[@]}; do
+			case $word in
+				$j | ${policy_opts[j]})
+					mode=policy
+					break 2
+					;;
+			esac
+		done
+		for j in ${!command_opts[@]}; do
+			case $word in
+				$j) # TODO "${command_opts[j]}" + conflict w/policy mode triggers: if followed by non-opt, set command mode, else pass through
+					mode=command
+					break 2
+					;;
+			esac
+		done
+	done
+
+	case ${mode-} in
+		show | hardware)
+			return 0
+			;;
+		command)
+			case $prev in
+				*) ;; # TODO
+			esac
+			return 0
+			;;
+		policy)
+			case $prev in
+				*) ;; # TODO
+			esac
+			return 0
+			;;
+		*)
+			# TODO offer all _opts
+			return 0
+			;;
+	esac
+
+	# --length | -l : g/m/k suffix
+
+} &&
+	complete -F _numactl numactl

--- a/numastat.bash
+++ b/numastat.bash
@@ -1,0 +1,47 @@
+# bash completion for numastat(8)
+
+_numastat() {
+
+	local cur=${COMP_WORDS[COMP_CWORD]}
+	local prev=${COMP_WORDS[COMP_CWORD - 1]}
+
+	local -A options=(
+		["-V"]=""
+		["-c"]=""
+		["-m"]=""
+		["-n"]=""
+		["-p"]=""
+		["-s"]="*"
+		["-v"]=""
+		["-z"]=""
+	)
+
+	local option word
+	for word in "${COMP_WORDS[@]}"; do
+		[[ $word != "$cur" || $prev != -p ]] || continue
+		for option in "${!options[@]}"; do
+			# shellcheck disable=SC2254
+			case $word in
+				$option | $option${options[$option]-})
+					unset "options[$option]" "options[-V]"
+					[[ $word != -V ]] || options=()
+					;;
+			esac
+		done
+	done
+
+	case $prev in
+		-V) return 0 ;;
+		-p) ;;
+		-*)
+			# shellcheck disable=SC2207,SC2016
+			COMPREPLY=($(compgen -W '${!options[@]}' -- "$cur"))
+			return
+			;;
+	esac
+
+	_pnames 2>/dev/null || : # from bash-completion, if around
+	# shellcheck disable=SC2207,SC2016
+	COMPREPLY+=($(compgen -W '$(command ps ax -o pid=)' -- "$cur"))
+} &&
+	complete -F _numastat numastat


### PR DESCRIPTION
Here goes bash completion for numastat. If seen desirable, I'll work on numactl completion later.

The benefit of shipping it here instead of the [bash-completion project](https://github.com/scop/bash-completion) is that here we have a luxury of being able to just hardcode known options and need to have the completion work only for these versions of executables, instead of having to scrape `--help` or so output to make it work with whatever version happens to be installed. And that the entire bash-completion is not needed if one wants just completions for things here.

This implementation is written without hard dependencies on bash-completion, it'll just use `_pnames` from it to produce process names, that's a [bit much](https://github.com/scop/bash-completion/blob/9d827b97e723c75305accee50ed0a1efec75bb5b/bash_completion#L1124) to be copied here.