### PR TITLE
Bash needs a noop if TLS isn't found.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ AC_PROG_CC
 # Override CFLAGS so that we can specify custom CFLAGS for numademo.
 AX_AM_OVERRIDE_VAR([CFLAGS])
 
-AX_TLS
+AX_TLS([:],[:])
 
 AX_CHECK_COMPILE_FLAG([-ftree-vectorize], [tree_vectorize="true"])
 AM_CONDITIONAL([HAVE_TREE_VECTORIZE], [test x"${tree_vectorize}" = x"true"])


### PR DESCRIPTION
Fix is from https://github.com/spack/spack/pull/21894

This bug fixes failures to configure on a number of HPC platforms

```
checking whether we are using the GNU C compiler... (cached) yes
checking whether /usr/WS2/blake14/spack/lib/spack/env/gcc/gcc accepts -g... (cached) yes
checking for /usr/WS2/blake14/spack/lib/spack/env/gcc/gcc option to accept ISO C89... (cached) none needed
checking whether /usr/WS2/blake14/spack/lib/spack/env/gcc/gcc understands -c and -o together... (cached) yes
checking dependency style of /usr/WS2/blake14/spack/lib/spack/env/gcc/gcc... (cached) gcc3
checking for thread local storage (TLS) class... _Thread_local
/g/g19/blake14/sand/numactl_fix/numactl/configure: line 12191: syntax error near unexpected token `fi'
/g/g19/blake14/sand/numactl_fix/numactl/configure: line 12191: `fi'
```

