### PR TITLE
libnuma: make numa_police_memory() free of race

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -864,8 +864,10 @@ void numa_police_memory(void *mem, size_t size)
 {
 	int pagesize = numa_pagesize_int();
 	unsigned long i;
-	for (i = 0; i < size; i += pagesize)
-        ((volatile char*)mem)[i] = ((volatile char*)mem)[i];
+	char *p = mem;
+	for (i = 0; i < size; i += pagesize, p += pagesize)
+		__atomic_and_fetch(p, 0xff, __ATOMIC_RELAXED);
+
 }
 
 make_internal_alias(numa_police_memory);


### PR DESCRIPTION
When numa_police_memory() read-write to memory, it can risk the race of
another thread write to the same area.

Using atomic function to protect the read-write operation

Signed-off-by: Pingfan Liu <piliu@redhat.com>