### PR TITLE
link with -latomic if needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,6 +151,7 @@ SED_PROCESS = \
         -e 's,@exec_prefix\@,$(exec_prefix),g' \
         -e 's,@libdir\@,$(libdir),g' \
         -e 's,@includedir\@,$(includedir),g' \
+        -e 's,@LIBS\@,$(LIBS),g' \
         < $< > $@ || rm $@
 
 %.pc: %.pc.in Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ AM_CONDITIONAL([HAVE_TREE_VECTORIZE], [test x"${tree_vectorize}" = x"true"])
 
 AC_CONFIG_FILES([Makefile])
 
+AC_SEARCH_LIBS([__atomic_fetch_and_1], [atomic])
+
 # GCC tries to be "helpful" and only issue a warning for unrecognized
 # attributes.  So we compile the test with Werror, so that if the
 # attribute is not recognized the compilation fails

--- a/numa.pc.in
+++ b/numa.pc.in
@@ -8,3 +8,4 @@ Description: NUMA policy library
 Version: @VERSION@
 Cflags: -I${includedir}
 Libs: -L${libdir} -lnuma
+Libs.Private: @LIBS@


### PR DESCRIPTION
numactl unconditionally uses `__atomic_fetch_and` but some architectures (e.g. sparc) needs to link with -latomic to be able to use it. So check if -latomic is needed and update numa.pc accordingly

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>