### PR TITLE
fix numa_node_size definition in manpage numa.3

### DIFF
--- a/numa.3
+++ b/numa.3
@@ -58,7 +58,7 @@ numa \- NUMA policy library
 .br
 .BI "struct bitmask *numa_parse_cpustring_all(const char *" string );
 .sp
-.BI "long numa_node_size(int " node ", long *" freep );
+.BI "long long numa_node_size(int " node ", long long*" freep );
 .br
 .BI "long long numa_node_size64(int " node ", long long *" freep );
 .sp

--- a/numa.3
+++ b/numa.3
@@ -414,11 +414,7 @@ On error it returns \-1.
 
 .BR numa_node_size64 ()
 works the same as
-.BR numa_node_size ()
-except that it returns values as
-.I long long
-instead of
-.IR long .
+.BR numa_node_size ().
 This is useful on 32-bit architectures with large nodes.
 
 .BR numa_preferred ()


### PR DESCRIPTION
fixes the documentation for numa_node_size in the numa.3 parameter and return type in man pages
(change was introduced in a7c4bc790a191d3e42b63850b409c1a72b75a4e1)