### PR TITLE
numactl.c: fix use after free

### DIFF
--- a/numactl.c
+++ b/numactl.c
@@ -544,6 +544,7 @@ int main(int ac, char **av)
 			if (nnodes != 1)
 				usage();
 			numa_bitmask_free(mask);
+			mask = NULL;
 			errno = 0;
 			did_node_cpu_parse = 1;
 			numa_set_bind_policy(0);


### PR DESCRIPTION
The following command can trigger the bug
  numactl --length 65536 --shm xxx -p0 -V > /dev/null

So reset mask to block any new access inside this loop.

Signed-off-by: Pingfan Liu <piliu@redhat.com>