### PR TITLE
fix segmentation fault with --offset and output wrong result with --verify

### DIFF
--- a/shm.c
+++ b/shm.c
@@ -295,7 +295,7 @@ void verify_shm(int policy, struct bitmask *nodes)
 			      policy_name(pol2), policy_name(policy));
 			goto out;
 		}
-		if (memcmp(nodes2, nodes, numa_bitmask_nbytes(nodes))) {
+		if (memcmp(nodes2->maskp, nodes->maskp, numa_bitmask_nbytes(nodes))) {
 			vwarn(p, "mismatched node mask\n");
 			printmask("expected", nodes);
 			printmask("real", nodes2);

--- a/shm.c
+++ b/shm.c
@@ -107,8 +107,8 @@ void attach_sysvshm(char *name, char *opt)
                      "need a --length to create a sysv shared memory segment");
 		fprintf(stderr,
          "numactl: Creating shared memory segment %s id %ld mode %04o length %.fMB\n",
-			name, shmid, shmmode, ((double)shmlen) / (1024*1024) );
-		shmfd = shmget(key, shmlen, IPC_CREAT|shmmode|shmflags);
+			name, shmid, shmmode, ((double)(shmlen + shmoffset)) / (1024*1024) );
+		shmfd = shmget(key, shmlen + shmoffset, IPC_CREAT|shmmode|shmflags);
 		if (shmfd < 0)
 			nerror("cannot create shared memory segment");
 	}
@@ -145,8 +145,12 @@ void attach_shared(char *name, char *opt)
 	}
 	if (fstat64(shmfd, &st) < 0)
 		err("shm stat");
-	if (shmlen > st.st_size) {
-		if (ftruncate64(shmfd, shmlen) < 0) {
+	/* the file size must be larger than mmap shmlen + shmoffset, otherwise SIGBUS
+	 * will be caused when we access memory, because mmaped memory is no longer in
+	 * the range of the file laster.
+	 */
+	if ((shmlen + shmoffset) > st.st_size) {
+		if (ftruncate64(shmfd, shmlen + shmoffset) < 0) {
 			/* XXX: we could do it by hand, but it would it
 			   would be impossible to apply policy then.
 			   need to fix that in the kernel. */


### PR DESCRIPTION
1、The following command can trigger the bug：numactl --offset 4096 --length 65536 --file xxx -p0 --touch > /dev/null
Because  we create a shm file, we just consider shmlen, but not consider shmoffset,resulting in the mapped memory is no within the scope of the new shm file. when we access these memory will cause SIGBUS.

2、the verify_shm function memcmp nodes，when nodemask_sz is  large 64, it will output "mismatched node mask",
that's not what we expected，we expected compare nodes->mask.