### PR TITLE
numactl: add support for new 'prefer-many-nodes' policy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ test_nodemap_LDADD = libnuma.la
 test_pagesize_SOURCES = test/pagesize.c
 test_pagesize_LDADD = libnuma.la
 
-test_prefered_SOURCES = test/prefered.c
+test_prefered_SOURCES = test/prefered.c util.c
 test_prefered_LDADD = libnuma.la
 
 test_randmap_SOURCES = test/randmap.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ numactl_LDADD = libnuma.la
 numastat_SOURCES = numastat.c
 numastat_CFLAGS = $(AM_CFLAGS) -std=gnu99
 
-numademo_SOURCES = numademo.c stream_lib.c stream_lib.h mt.c mt.h clearcache.c clearcache.h
+numademo_SOURCES = numademo.c stream_lib.c stream_lib.h mt.c mt.h clearcache.c util.c clearcache.h
 numademo_CPPFLAGS = $(AM_CPPFLAGS) -DHAVE_STREAM_LIB -DHAVE_MT -DHAVE_CLEAR_CACHE
 numademo_CFLAGS = $(AM_CFLAGS) -O3 -ffast-math -funroll-loops
 if HAVE_TREE_VECTORIZE

--- a/libnuma.c
+++ b/libnuma.c
@@ -857,7 +857,7 @@ numa_tonodemask_memory_v2(void *mem, size_t size, struct bitmask *bmp)
 
 void numa_setlocal_memory(void *mem, size_t size)
 {
-	dombind(mem, size, MPOL_PREFERRED, NULL);
+	dombind(mem, size, MPOL_LOCAL, NULL);
 }
 
 void numa_police_memory(void *mem, size_t size)
@@ -1034,7 +1034,7 @@ void *numa_alloc_local(size_t size)
 	if (mem == (char *)-1)
 		mem =  NULL;
 	else
-		dombind(mem, size, MPOL_PREFERRED, NULL);
+		dombind(mem, size, MPOL_LOCAL, NULL);
 	return mem;
 }
 
@@ -1799,13 +1799,13 @@ void numa_set_preferred(int node)
 		numa_bitmask_setbit(bmp, node);
 		setpol(MPOL_PREFERRED, bmp);
 	} else
-		setpol(MPOL_DEFAULT, bmp);
+		setpol(MPOL_LOCAL, bmp);
 	numa_bitmask_free(bmp);
 }
 
 void numa_set_localalloc(void)
 {
-	setpol(MPOL_DEFAULT, numa_no_nodes_ptr);
+	setpol(MPOL_LOCAL, numa_no_nodes_ptr);
 }
 
 SYMVER("numa_bind_v1", "numa_bind@libnuma_1.1")

--- a/libnuma.c
+++ b/libnuma.c
@@ -1070,6 +1070,8 @@ void numa_set_bind_policy(int strict)
 {
 	if (strict)
 		bind_policy = MPOL_BIND;
+	else if (has_preferred_many)
+		bind_policy = MPOL_PREFERRED_MANY;
 	else
 		bind_policy = MPOL_PREFERRED;
 }
@@ -1837,6 +1839,20 @@ void numa_set_preferred(int node)
 int numa_has_preferred_many(void)
 {
 	return has_preferred_many;
+}
+
+void numa_set_preferred_many(struct bitmask *bitmask)
+{
+	if (!has_preferred_many) {
+		numa_error("Unable to handle MANY preferred nodes. Falling back to first node\n");
+		__numa_set_preferred(bitmask);
+	}
+	setpol(MPOL_PREFERRED_MANY, bitmask);
+}
+
+struct bitmask *numa_preferred_many()
+{
+	return __numa_preferred();
 }
 
 void numa_set_localalloc(void)

--- a/libnuma.c
+++ b/libnuma.c
@@ -1768,25 +1768,23 @@ out:
 int numa_preferred(void)
 {
 	int policy;
-	int ret;
 	struct bitmask *bmp;
+	/* could read the current CPU from /proc/self/status. Probably
+	   not worth it. */
+	int ret = 0;
 
 	bmp = numa_allocate_nodemask();
 	getpol(&policy, bmp);
-	if (policy == MPOL_PREFERRED || policy == MPOL_BIND) {
-		int i;
-		int max = numa_num_possible_nodes();
-		for (i = 0; i < max ; i++)
-			if (numa_bitmask_isbitset(bmp, i)){
-				ret = i;
-				goto end;
-			}
-	}
-	/* could read the current CPU from /proc/self/status. Probably
-	   not worth it. */
-	ret = 0; /* or random one? */
-end:
-	numa_bitmask_free(bmp);
+
+	if (policy != MPOL_PREFERRED && policy != MPOL_BIND)
+		return ret;
+
+	int i;
+	int max = numa_num_possible_nodes();
+	for (i = 0; i < max ; i++)
+		if (numa_bitmask_isbitset(bmp, i))
+			ret = i;
+
 	return ret;
 }
 

--- a/libnuma.c
+++ b/libnuma.c
@@ -1806,7 +1806,9 @@ static struct bitmask *__numa_preferred(void)
 	numa_bitmask_clearall(bmp);
 	getpol(&policy, bmp);
 
-	if (policy != MPOL_PREFERRED && policy != MPOL_BIND)
+	if (policy != MPOL_PREFERRED &&
+			policy != MPOL_PREFERRED_MANY &&
+			policy != MPOL_BIND)
 		return bmp;
 
 	if (numa_bitmask_weight(bmp) > 1)

--- a/numa.3
+++ b/numa.3
@@ -64,7 +64,13 @@ numa \- NUMA policy library
 .sp
 .B int numa_preferred(void);
 .br
+.B int numa_has_preferred_many(void);
+.br
+.B struct bitmask *numa_preferred_many(void);
+.br
 .BI "void numa_set_preferred(int " node );
+.br
+.BI "void numa_set_preferred_many(struct bitmask *" nodemask );
 .br
 .BI "int numa_get_interleave_node(void);
 .br
@@ -427,6 +433,16 @@ allocates memory, unless some other policy overrides this.
 .\" order of the current node's zonelist to return the correct
 .\" node.  Need to tighten this up with the syscall results.
 
+.BR numa_has_preferred_many ()
+Returns > 0 if the system supports multiple preferred nodes.
+
+.BR numa_preferred_many ()
+Returns the current set of preferred nodes. This implies the empty set when the
+policy isn't one used for preference
+.I (PREFERRED, PREFERRED_MANY, BIND).
+The caller is responsible for freeing the mask with
+.BR numa_bitmask_free ().
+
 .BR numa_set_preferred ()
 sets the preferred node for the current task to
 .IR node .
@@ -438,6 +454,16 @@ Passing a
 of \-1 argument specifies local allocation and is equivalent to
 calling
 .BR numa_set_localalloc ().
+
+.BR numa_set_preferred_many ()
+sets the preferred set of nodes for the current task to
+.IR nodemask .
+This is similar to
+.BR numa_set_preferred ()
+with the exception that it utilizes a different kernel interface to specify
+multiple preferred nodes.
+The caller is responsible for freeing the mask with
+.BR numa_bitmask_free ().
 
 .BR numa_get_interleave_mask ()
 returns the current interleave mask if the task's memory allocation policy

--- a/numa.h
+++ b/numa.h
@@ -189,6 +189,12 @@ void numa_set_preferred(int node);
 /* Returns whether or not the platform supports MPOL_PREFERRED_MANY */
 int numa_has_preferred_many(void);
 
+/* Set of nodes to preferably allocate memory from for task. */
+void numa_set_preferred_many(struct bitmask *bitmask);
+
+/* Return preferred nodes */
+struct bitmask *numa_preferred_many(void);
+
 /* Set local memory allocation policy for task */
 void numa_set_localalloc(void);
 

--- a/numa.h
+++ b/numa.h
@@ -186,6 +186,9 @@ static inline void numa_free_nodemask(struct bitmask *b)
 /* Some node to preferably allocate memory from for task. */
 void numa_set_preferred(int node);
 
+/* Returns whether or not the platform supports MPOL_PREFERRED_MANY */
+int numa_has_preferred_many(void);
+
 /* Set local memory allocation policy for task */
 void numa_set_localalloc(void);
 

--- a/numactl.8
+++ b/numactl.8
@@ -31,6 +31,8 @@ numactl \- Control NUMA policy for processes or shared memory
 ] [
 .B \-\-preferred node 
 ] [
+.B \-\-preferred-many nodes
+] [
 .B \-\-membind nodes
 ] [ 
 .B \-\-cpunodebind nodes
@@ -176,6 +178,14 @@ This should only be used with
 .I \-\-membind, \-m
 only, otherwise ignored.
 .TP
+.B \-\-preferred-many=node
+Preferably allocate memory on
+.I nodes,
+but if memory cannot be allocated there fall back to other nodes.
+This option takes a mask of preferred nodes where the closest node to local is
+considered most preferred.
+Relative notation may be used.
+.TP
 .B \-\-show, \-s
 Show NUMA policy settings of the current process. 
 .TP
@@ -195,6 +205,7 @@ above (
 .I \-\-interleave, 
 .I \-\-localalloc, 
 .I \-\-preferred,
+.I \-\-preferred-many,
 .I \-\-membind
 ).
 .TP
@@ -296,6 +307,9 @@ also in the same node.
 
 numactl \-\-preferred=1 numactl \-\-show
 Set preferred node 1 and show the resulting state.
+
+numactl \-\-preferred-many=0x3 numactl \-\-show
+Set preferred nodes 1 and 2, and show the resulting state.
 
 numactl --interleave=all --shm /tmp/shmkey 
 Interleave all of the sysv shared memory region specified by

--- a/numactl.c
+++ b/numactl.c
@@ -554,7 +554,7 @@ int main(int ac, char **av)
 			break;
 		case 'l': /* --local */
 			checknuma();
-			setpolicy(MPOL_DEFAULT);
+			setpolicy(MPOL_LOCAL);
 			errno = 0;
 			if (shmfd >= 0)
 				numa_setlocal_memory(shmptr, shmlen);

--- a/numactl.c
+++ b/numactl.c
@@ -420,7 +420,7 @@ static struct bitmask *numactl_parse_nodestring(char *s, int flag)
 
 int main(int ac, char **av)
 {
-	int c, i, nnodes=0;
+	int c;
 	long node=-1;
 	char *end;
 	char shortopts[array_len(opts)*2 + 1];
@@ -535,13 +535,7 @@ int main(int ac, char **av)
 				printf ("<%s> is invalid\n", optarg);
 				usage();
 			}
-			for (i=0; i<mask->size; i++) {
-				if (numa_bitmask_isbitset(mask, i)) {
-					node = i;
-					nnodes++;
-				}
-			}
-			if (nnodes != 1)
+			if (numa_bitmask_weight(mask) != 1)
 				usage();
 			errno = 0;
 			did_node_cpu_parse = 1;
@@ -549,7 +543,8 @@ int main(int ac, char **av)
 			if (shmfd >= 0)
 				numa_tonode_memory(shmptr, shmlen, node);
 			else
-				numa_set_preferred(node);
+				numa_set_preferred(find_first(mask));
+			numa_bitmask_free(mask);
 			checkerror("setting preferred node");
 			break;
 		case 'l': /* --local */

--- a/numademo.c
+++ b/numademo.c
@@ -24,6 +24,7 @@
 #include <ctype.h>
 #include <sys/time.h>
 #include "numa.h"
+#include "util.h"
 #ifdef HAVE_STREAM_LIB
 #include "stream_lib.h"
 #endif
@@ -464,19 +465,6 @@ void usage(void)
 		printf(" %s", testname[i]);
 	putchar('\n');
 	exit(1);
-}
-
-/* duplicated to make numademo standalone */
-long memsize(char *s)
-{
-	char *end;
-	long length = strtoul(s,&end,0);
-	switch (toupper(*end)) {
-	case 'G': length *= 1024;  /*FALL THROUGH*/
-	case 'M': length *= 1024;  /*FALL THROUGH*/
-	case 'K': length *= 1024; break;
-	}
-	return length;
 }
 
 int main(int ac, char **av)

--- a/numaif.h
+++ b/numaif.h
@@ -27,7 +27,8 @@ extern long move_pages(int pid, unsigned long count,
 #define MPOL_BIND        2
 #define MPOL_INTERLEAVE  3
 #define MPOL_LOCAL       4
-#define MPOL_MAX         5
+#define MPOL_PREFERRED_MANY   5
+#define MPOL_MAX         6
 
 /* Flags for set_mempolicy, specified in mode */
 #define MPOL_F_NUMA_BALANCING	(1 << 13) /* Optimize with NUMA balancing if possible */

--- a/shm.c
+++ b/shm.c
@@ -315,6 +315,7 @@ void verify_shm(int policy, struct bitmask *nodes)
 			}
 			ilnode = interleave_next(ilnode, nodes2);
 			break;
+		case MPOL_PREFERRED_MANY:
 		case MPOL_PREFERRED:
 		case MPOL_BIND:
 			if (!numa_bitmask_isbitset(nodes2, node)) {

--- a/test/prefered.c
+++ b/test/prefered.c
@@ -10,6 +10,10 @@
 
 #define err(x) perror(x),exit(1)
 
+void usage(void)
+{
+}
+
 int main(void)
 {
 	int max = numa_max_node();

--- a/test/prefered.c
+++ b/test/prefered.c
@@ -10,6 +10,8 @@
 
 #define err(x) perror(x),exit(1)
 
+extern void printmask(char *name, struct bitmask *mask);
+
 void usage(void)
 {
 }
@@ -27,6 +29,8 @@ int main(void)
 	nodes = numa_bitmask_alloc(maxmask);
 	mask = numa_bitmask_alloc(maxmask);
 
+	/* Step 1. test 'preferred' policy */
+	printf("\nTesting MPOL_PREFERRED policy:\n\n");
 	for (i = max; i >= 0; --i) {
 		char *mem = mmap(NULL, pagesize*(max+1), PROT_READ|PROT_WRITE,
 					MAP_PRIVATE|MAP_ANONYMOUS, 0, 0);
@@ -63,5 +67,51 @@ int main(void)
 		if (node != i)
 			err = 1;
 	}
+
+
+	/* Step 2. test 'preferred-many' policy */
+	if (max < 1)
+		return err;
+
+	printf("\nTesting MPOL_PREFERRED_MANY policy:\n\n");
+	for (i = max; i >= 1; --i) {
+		char *mem = mmap(NULL, pagesize*(max+1), PROT_READ|PROT_WRITE,
+					MAP_PRIVATE|MAP_ANONYMOUS, 0, 0);
+		char *adr = mem;
+
+		if (mem == (char *)-1)
+			err("mmap");
+
+		numa_bitmask_clearall(nodes);
+		numa_bitmask_clearall(mask);
+		/* Set 2 nodes */
+		numa_bitmask_setbit(nodes, i);
+		numa_bitmask_setbit(nodes, i - 1);
+
+		if (mbind(adr,  pagesize, MPOL_PREFERRED_MANY, nodes->maskp,
+							nodes->size, 0) < 0)
+			err("mbind");
+
+		++*adr;
+		if (get_mempolicy(&pol, mask->maskp, mask->size, adr, MPOL_F_ADDR) < 0)
+			err("get_mempolicy");
+
+		assert(pol == MPOL_PREFERRED_MANY);
+		printmask("Got nodes", mask);
+		printmask("Expected nodes", nodes);
+		if (!numa_bitmask_equal(mask, nodes))
+			err = 1;
+
+		node = 0x123;
+		if (get_mempolicy(&node, NULL, 0, adr, MPOL_F_ADDR|MPOL_F_NODE) < 0)
+			err("get_mempolicy2");
+
+		printf("Got node: %d ", node);
+		printmask("Expected nodes", nodes);
+
+		if (!numa_bitmask_isbitset(nodes, node))
+			err = 1;
+	}
+
 	return err;
 }

--- a/util.c
+++ b/util.c
@@ -86,6 +86,7 @@ static struct policy {
 	int policy;
 	int noarg;
 } policies[] = {
+	{ "local", MPOL_LOCAL, 1 },
 	{ "interleave", MPOL_INTERLEAVE, },
 	{ "membind",    MPOL_BIND, },
 	{ "preferred",   MPOL_PREFERRED, },
@@ -93,7 +94,7 @@ static struct policy {
 	{ NULL },
 };
 
-static char *policy_names[] = { "default", "preferred", "bind", "interleave" };
+static char *policy_names[] = { "default", "preferred", "bind", "interleave", "local" };
 
 char *policy_name(int policy)
 {

--- a/util.c
+++ b/util.c
@@ -86,6 +86,7 @@ static struct policy {
 	int policy;
 	int noarg;
 } policies[] = {
+	{ "preferred-many", MPOL_PREFERRED_MANY, },
 	{ "local", MPOL_LOCAL, 1 },
 	{ "interleave", MPOL_INTERLEAVE, },
 	{ "membind",    MPOL_BIND, },
@@ -94,7 +95,7 @@ static struct policy {
 	{ NULL },
 };
 
-static char *policy_names[] = { "default", "preferred", "bind", "interleave", "local" };
+static char *policy_names[] = { "default", "preferred", "bind", "interleave", "local", "preferred-many" };
 
 char *policy_name(int policy)
 {

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -154,3 +154,11 @@ libnuma_1.5 {
   local:
     *;
 } libnuma_1.4;
+
+
+libnuma_1.6{
+  global:
+    numa_has_preferred_many;
+  local:
+    *;
+} libnuma_1.5;

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -159,6 +159,8 @@ libnuma_1.5 {
 libnuma_1.6{
   global:
     numa_has_preferred_many;
+    numa_set_preferred_many;
+    numa_preferred_many;
   local:
     *;
 } libnuma_1.5;


### PR DESCRIPTION
Linux kernel 5.15 has merged a new memory policy "MPOL_PREFERRED_MANY", which allows user to specified multiple nodes as the preferred list to first allocate memory from, and till there is no available memory on those nodes, it will fallback to all other memory nodes in system.

This patchset adds the support in numactl/libnuma, and user can chose this policy by:

   numactl [--preferred-many= | -P <nodes>]

And with older kernel, it will return with warning message:
  "numactl: preferred-many requested without kernel support"


