### PR TITLE
Fix build error on riscv64 by linking libatomic

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,9 @@ memhog_LDADD = libnuma.la
 
 libnuma_la_SOURCES = libnuma.c syscall.c distance.c affinity.c affinity.h sysfs.c sysfs.h rtnetlink.c rtnetlink.h versions.ldscript
 libnuma_la_LDFLAGS = -version-info 1:0:0 -Wl,--version-script,$(srcdir)/versions.ldscript -Wl,-init,numa_init -Wl,-fini,numa_fini
+if RISCV64
+libnuma_la_LDFLAGS += -latomic
+endif
 
 check_PROGRAMS = \
 	test/distance \

--- a/configure.ac
+++ b/configure.ac
@@ -17,14 +17,15 @@ AC_PROG_CC
 # Override CFLAGS so that we can specify custom CFLAGS for numademo.
 AX_AM_OVERRIDE_VAR([CFLAGS])
 
-AX_TLS([:],[:])
+AX_TLS
 
 AX_CHECK_COMPILE_FLAG([-ftree-vectorize], [tree_vectorize="true"])
 AM_CONDITIONAL([HAVE_TREE_VECTORIZE], [test x"${tree_vectorize}" = x"true"])
 
-AC_CONFIG_FILES([Makefile])
+AC_CANONICAL_TARGET
+AM_CONDITIONAL([RISCV64], [test x"${target_cpu}" = x"riscv64"])
 
-AC_SEARCH_LIBS([__atomic_fetch_and_1], [atomic])
+AC_CONFIG_FILES([Makefile])
 
 # GCC tries to be "helpful" and only issue a warning for unrecognized
 # attributes.  So we compile the test with Werror, so that if the


### PR DESCRIPTION
numactl currently failed to build on riscv64 from source ([Full Debian buildd log](https://buildd.debian.org/status/fetch.php?pkg=numactl&arch=riscv64&ver=2.0.14-3&stamp=1632275973&raw=0)):

```
...
/usr/bin/ld: ./.libs/libnuma.so: undefined reference to `__atomic_fetch_and_1'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:899: migratepages] Error 1
make[2]: *** Waiting for unfinished jobs....
/usr/bin/ld: ./.libs/libnuma.so: undefined reference to `__atomic_fetch_and_1'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:903: migspeed] Error 1
/usr/bin/ld: ./.libs/libnuma.so: undefined reference to `__atomic_fetch_and_1'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:907: numactl] Error 1
/usr/bin/ld: ./.libs/libnuma.so: undefined reference to `__atomic_fetch_and_1'
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:911: numademo] Error 1
...
```

This can be fixed by linking to libatomic on riscv64, which I've done in this PR.