### PR TITLE
link with -latomic if needed (again ...)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,8 @@ AM_CONDITIONAL([RISCV64], [test x"${target_cpu}" = x"riscv64"])
 
 AC_CONFIG_FILES([Makefile])
 
+AC_SEARCH_LIBS([__atomic_fetch_and_1], [atomic])
+
 # GCC tries to be "helpful" and only issue a warning for unrecognized
 # attributes.  So we compile the test with Werror, so that if the
 # attribute is not recognized the compilation fails


### PR DESCRIPTION
numactl unconditionally uses `__atomic_fetch_and` but some architectures (e.g. sparc) needs to link with -latomic to be able to use it. So check if -latomic is needed and update numa.pc accordingly.

This linking was made by e0de0d9e981ddb53bdeb4a4b9dc43046c9ff4ff9 but wrongly reverted by 10c277c20768be9a563f75265bcd7e73954763ad resulting in the following build failure on sparc or microblaze:

`/nvmedata/autobuild/instance-7/output-1/per-package/numactl/host/bin/../lib/gcc/sparc-buildroot-linux-uclibc/10.4.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: ./.libs/libnuma.a(libnuma.o): in function `numa_police_memory': libnuma.c:(.text+0xe28): undefined reference to `__atomic_fetch_and_1'`

Fixes:
 - http://autobuild.buildroot.org/results/54b7567d804d9abff56f47cd26bae774c1e38669

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>