### PR TITLE
numactl: Fix shm verfiy for preferred policy

### DIFF
--- a/numactl.c
+++ b/numactl.c
@@ -548,7 +548,7 @@ int main(int ac, char **av)
 			did_node_cpu_parse = 1;
 			numa_set_bind_policy(0);
 			if (shmfd >= 0) {
-				numa_tonode_memory(shmptr, shmlen, node);
+				numa_tonode_memory(shmptr, shmlen, find_first(mask));
 				/* Correspond to numa_set_bind_policy function */
 				if (numa_has_preferred_many()) {
 					setpolicy(MPOL_PREFERRED_MANY);

--- a/numactl.c
+++ b/numactl.c
@@ -549,6 +549,12 @@ int main(int ac, char **av)
 			numa_set_bind_policy(0);
 			if (shmfd >= 0) {
 				numa_tonode_memory(shmptr, shmlen, node);
+				/* Correspond to numa_set_bind_policy function */
+				if (numa_has_preferred_many()) {
+					setpolicy(MPOL_PREFERRED_MANY);
+				} else {
+					setpolicy(MPOL_PREFERRED);
+				}
 			} else if (c == 'p') {
 				if (numa_bitmask_weight(mask) != 1)
 					usage();


### PR DESCRIPTION
The following command can report  "numactl: Need a policy first to verify"

    numactl --length=4096 --shm abc -p0 --verify

when policy uses perferred, set_policy isn't set.

Fixes: 0c844d8c("Update to support multiple nodes")

#155

'numactl --length=xxx --shm xxx -px' doesn't work

When preferred is used for shm, no value is assigned to the variable node. 
As a result, it does not take effect.

fixes: 5862e0e4("numactl: Simplify preferred selection")
#158 
