### PR TITLE
numactl.c: Remove unused variable

### DIFF
--- a/numactl.c
+++ b/numactl.c
@@ -422,7 +422,6 @@ static struct bitmask *numactl_parse_nodestring(char *s, int flag)
 int main(int ac, char **av)
 {
 	int c;
-	long node=-1;
 	char *end;
 	char shortopts[array_len(opts)*2 + 1];
 	struct bitmask *mask = NULL;


### PR DESCRIPTION
This patch is to remove the following unused variable warning.
```
  numactl.c: In function 'main':
  numactl.c:425:14: warning: unused variable 'node' [-Wunused-variable]
    425 |         long node=-1;
        |              ^~~~
```
Since node is used nowhere inside the function so remove it.

Signed-off-by: Honggyu Kim <honggyu.kp@gmail.com>