### PR TITLE
migspeed don't have to be linked against librt

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ migratepages_SOURCES = migratepages.c util.c
 migratepages_LDADD = libnuma.la
 
 migspeed_SOURCES = migspeed.c util.c
-migspeed_LDADD = libnuma.la -lrt
+migspeed_LDADD = libnuma.la 
 
 memhog_SOURCES = memhog.c util.c
 memhog_LDADD = libnuma.la


### PR DESCRIPTION
The link command fails for wig speed with the android ndk. Also on x86_64 linux it is not needed.

reference for an "external" patch:
https://github.com/input-output-hk/haskell.nix/pull/1343/files#diff-67a1159ec1fe8bb87ad7d62668fc77d67227332e88eb5762582d24834bdab632