### PR TITLE
Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/numactl/numactl/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Resolves https://github.com/numactl/numactl/issues/174

Hi there! If you like to consider this change, here's a Security Policy suggestion.

Please not that the link for reporting vulnerabilities uses the [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) GitHub feature. You would need to enable the feature in the repo for the reports to start working. If you prefer an email for reporting, I can update the PR. If you decide to use the private vulnerability reporting, you can enable it following the instructions [here](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository#enabling-or-disabling-private-vulnerability-reporting-for-a-repository).

I've tried to keep the timelines of confirming a vulnerability report and fixing a vulnerability as open as possible. Let me know what you think and if this seems reasonable for maintainance.