### PR TITLE
numactl.c: Refactor print_node_cpus to display CPU ranges

### DIFF
--- a/numactl.c
+++ b/numactl.c
@@ -231,7 +231,7 @@ static void print_distances(int maxnode)
 
 static void print_node_cpus(int node)
 {
-    int i = 0, err, start, segment = 0;
+    int i = 0, err, start, segment = 0, count = 0;
     struct bitmask *cpus;
 
     cpus = numa_allocate_cpumask();
@@ -262,6 +262,7 @@ static void print_node_cpus(int node)
         }
 
         int end = i - 1; // The end of the current range.
+	count += (end - start) + 1;
         if (start == end) {
             // If it's a single CPU (no range), we print it directly.
             printf(" %d", start);
@@ -272,7 +273,7 @@ static void print_node_cpus(int node)
         segment++; // Update the count of printed segments.
     }
 
-    putchar('\n'); // Newline for cleaner output formatting.
+    printf(" (%d)\n", count); // Newline for cleaner output formatting.
 
 out:
     numa_free_cpumask(cpus); // Cleanup the allocated bitmask.

--- a/numactl.c
+++ b/numactl.c
@@ -237,46 +237,41 @@ static void print_node_cpus(int node)
     cpus = numa_allocate_cpumask();
     err = numa_node_to_cpus(node, cpus);
     if (err < 0) {
-        goto out; // If there's an error, we jump to cleanup.
+        goto out;
     }
 
-    // Main loop over each CPU in the bitmask.
     while (i < cpus->size) {
         start = -1;
 
-        // If the bit is set, we're in a range of available CPUs.
+	// Find the start and end of a range of available CPUs.
         while (i < cpus->size && numa_bitmask_isbitset(cpus, i)) {
-            if (start == -1) start = i; // We've found the start of a range.
+            if (start == -1) start = i;
             i++;
         }
 
-        // If start is still -1, the current bit wasn't set, and we move to the next iteration.
         if (start == -1) {
             i++;
             continue;
         }
 
-        // Formatting the output: we put a comma before all segments, except the first.
         if (segment) {
             printf(",");
         }
 
-        int end = i - 1; // The end of the current range.
+        int end = i - 1;
 	count += (end - start) + 1;
         if (start == end) {
-            // If it's a single CPU (no range), we print it directly.
             printf(" %d", start);
         } else {
-            // Otherwise, we print the range.
             printf(" %d-%d", start, end);
         }
-        segment++; // Update the count of printed segments.
+        segment++;
     }
 
-    printf(" (%d)\n", count); // Newline for cleaner output formatting.
+    printf(" (%d)\n", count);
 
 out:
-    numa_free_cpumask(cpus); // Cleanup the allocated bitmask.
+    numa_free_cpumask(cpus); 
 }
 
 static void hardware(void)


### PR DESCRIPTION
This commit refines the `print_node_cpus` function to enhance output readability, especially for systems with numerous CPUs. Initially, the function itemized each CPU, leading to potentially lengthy and cluttered outputs. With this update, the function now identifies and prints contiguous CPU ranges as hyphen-separated sequences (e.g., 1-4) instead of individual lists (e.g., 1 2 3 4), streamlining the display.

Additionally, to provide a quick overview, a count of the total available CPUs is appended at the end of the output, allowing users to instantly grasp the total number without manual counting.

While the output strategy underwent these improvements, the function's core logic, error-handling, and interactions with the NUMA library remain intact, ensuring reliability and consistency with previous behavior.

Signed-off-by: Vishal Chourasia <vishalc@linux.ibm.com>