### PR TITLE
Revert "Fix build error on riscv64 by linking libatomic"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,9 +41,6 @@ memhog_LDADD = libnuma.la
 
 libnuma_la_SOURCES = libnuma.c syscall.c distance.c affinity.c affinity.h sysfs.c sysfs.h rtnetlink.c rtnetlink.h versions.ldscript
 libnuma_la_LDFLAGS = -version-info 1:0:0 -Wl,--version-script,$(srcdir)/versions.ldscript -Wl,-init,numa_init -Wl,-fini,numa_fini
-if RISCV64
-libnuma_la_LDFLAGS += -latomic
-endif
 
 check_PROGRAMS = \
 	test/distance \

--- a/configure.ac
+++ b/configure.ac
@@ -20,13 +20,10 @@ AC_SYS_LARGEFILE
 # Override CFLAGS so that we can specify custom CFLAGS for numademo.
 AX_AM_OVERRIDE_VAR([CFLAGS])
 
-AX_TLS
+AX_TLS([:],[:])
 
 AX_CHECK_COMPILE_FLAG([-ftree-vectorize], [tree_vectorize="true"])
 AM_CONDITIONAL([HAVE_TREE_VECTORIZE], [test x"${tree_vectorize}" = x"true"])
-
-AC_CANONICAL_TARGET
-AM_CONDITIONAL([RISCV64], [test x"${target_cpu}" = x"riscv64"])
 
 AC_CONFIG_FILES([Makefile])
 


### PR DESCRIPTION
This reverts commit 10c277c20768be9a563f75265bcd7e73954763ad.

Whether `-latomic` needs to be linked or not depends on the used toolchain, not the architecture of the platform we build for. In my case I'm building on a riscv64 system using the LLVM toolchain, so there's not even a `-latomic` to link against. But the current logic tries to link `-latomic` anyway, resulting in a build failure.

The correct way to detect whether the used toolchain needs to link `-latomic` explicitly in order to use `__atomic_fetch_and_1` seems to be `AC_SEARCH_LIBS`.
This was
  1.) introduced in e0de0d9e981d ("link with -latomic if needed")
  2.) wrongly removed in commit 10c277c20768 ("Fix build error on riscv64 by linking libatomic").
  3.) reinstantiated in commit 18ec3b973b72 ("link with -latomic if needed (again ...)")

The build log[1] referenced in the PR[2] that introduced the unconditional linking of `-latomic` on riscv64 shows that the build error happened with version 2.0.14, but the commit introducing the usage of `AC_SEARCH_LIBS` was merged after that:

  $ git --no-pager tag --contains e0de0d9e981d
  v2.0.15
  v2.0.16

So it looks like e0de0d9e981d ("link with -latomic if needed") fixed the problem for both scenarios and 10c277c20768 ("Fix build error on riscv64 by linking libatomic") wasn't necessary at all after it.

[1] https://buildd.debian.org/status/fetch.php?pkg=numactl&arch=riscv64&ver=2.0.14-3&stamp=1632275973&raw=0
[2] https://github.com/numactl/numactl/pull/131