### PR TITLE
Include <fcntl.h> instead of <sys/fcntl.h>

### DIFF
--- a/memhog.c
+++ b/memhog.c
@@ -15,10 +15,10 @@
    on your Linux system; if not, write to the Free Software Foundation,
    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/mman.h>
-#include <sys/fcntl.h>
 #include <string.h>
 #include <stdbool.h>
 #include "numa.h"

--- a/sysfs.c
+++ b/sysfs.c
@@ -1,7 +1,7 @@
 /* Utility functions for reading sysfs values */
 #define _GNU_SOURCE 1
+#include <fcntl.h>
 #include <stdio.h>
-#include <sys/fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdarg.h>


### PR DESCRIPTION
Fixes the following warnings when building on systems using the musl libc:
```
In file included from sysfs.c:4:
/usr/riscv64-unknown-linux-musl/include/sys/fcntl.h:1:2: warning: redirecting incorrect #include <sys/fcntl.h> to <fcntl.h> [-W#warnings]
    1 | #warning redirecting incorrect #include <sys/fcntl.h> to <fcntl.h>
      |  ^
1 warning generated.
```

On systems using glibc this is also just a wrapper:
```
$ cat /usr/include/sys/fcntl.h
```