### PR TITLE
Draft: distance: Remove unused variable (NFC)

### DIFF
--- a/distance.c
+++ b/distance.c
@@ -31,11 +31,6 @@ static void parse_numbers(char *s, int *iptr)
 	int i, d, j;
 	char *end;
 	int maxnode = numa_max_node();
-	int numnodes = 0;
-
-	for (i = 0; i <= maxnode; i++)
-		if (numa_bitmask_isbitset(numa_nodes_ptr, i))
-			numnodes++;
 
 	for (i = 0, j = 0; i <= maxnode; i++, j++) {
 		d = strtoul(s, &end, 0);


### PR DESCRIPTION
clang-17 warns about this set but unused variable:
```
distance.c:34:6: warning: variable 'numnodes' set but not used [-Wunused-but-set-variable]
   34 |         int numnodes = 0;
      |             ^
1 warning generated.
```

and it's indeed just used to count the nodes in the for loop but then it's never used