### PR TITLE
fix complain() fuction print newline

### DIFF
--- a/util.c
+++ b/util.c
@@ -49,7 +49,7 @@ void complain(char *fmt, ...)
 	va_start(ap, fmt);
 	fprintf(stderr, "numactl: ");
 	vfprintf(stderr,fmt,ap);
-	putchar('\n');
+	fputc('\n', stderr);
 	va_end(ap);
 	exit(1);
 }


### PR DESCRIPTION
When using the complain() function to output stderr, the newline character doesn't take effect.
```shell
[luochenglcs@TENCENT64 numactl]$ numactl --shm xxx --touch > /dev/null
numactl: need a --length to create a sysv shared memory segment[luochenglcs@TENCENT64 numactl]$
```

After fixed:
```shell
[luochenglcs@TENCENT64 numactl]$ numactl --shm xxx --touch > /dev/null
numactl: need a --length to create a sysv shared memory segment
[luochenglcs@TENCENT64 numactl]$ 
```