### PR TITLE
libnuma: add numa_set_mempolicy_home_node API

### DIFF
--- a/numa.3
+++ b/numa.3
@@ -72,6 +72,10 @@ numa \- NUMA policy library
 .br
 .BI "void numa_set_preferred_many(struct bitmask *" nodemask );
 .br
+.BI "int numa_has_home_node(void);
+.br
+.BI "int numa_set_mempolicy_home_node(void *start, unsigned long len, int home_node, int flags);
+.br
 .BI "int numa_get_interleave_node(void);
 .br
 .B struct bitmask *numa_get_interleave_mask(void);
@@ -464,6 +468,15 @@ with the exception that it utilizes a different kernel interface to specify
 multiple preferred nodes.
 The caller is responsible for freeing the mask with
 .BR numa_bitmask_free ().
+
+.BR numa_has_home_node()
+Returns 1 if the system supports setting home_node for mbind and preferred_many.
+
+.BR numa_set_mempolicy_home_node()
+set the home node for a VMA policy present in the task's address range.
+A home node is the NUMA node closest to which page allocation will come from.
+Users should use it after setting up a mbind or perfered_many memory policy
+for the specified range.
 
 .BR numa_get_interleave_mask ()
 returns the current interleave mask if the task's memory allocation policy

--- a/numa.h
+++ b/numa.h
@@ -341,6 +341,15 @@ struct bitmask *numa_parse_cpustring(const char *);
  * dependency */
 struct bitmask *numa_parse_cpustring_all(const char *);
 
+/* Returns whether or not the system supports setting home_node for mbind
+ * and preferred_many.
+ */
+int numa_has_home_node(void);
+
+/* set the home node for a VMA policy present in the task's address range */
+int numa_set_mempolicy_home_node(void *start, unsigned long len,
+		int home_node, int flags);
+
 /*
  * The following functions are for source code compatibility
  * with releases prior to version 2.

--- a/numaif.h
+++ b/numaif.h
@@ -21,6 +21,9 @@ extern long migrate_pages(int pid, unsigned long maxnode,
 extern long move_pages(int pid, unsigned long count,
 		void **pages, const int *nodes, int *status, int flags);
 
+extern int set_mempolicy_home_node(void *start, unsigned long len,
+		int home_node, int flag);
+
 /* Policies */
 #define MPOL_DEFAULT     0
 #define MPOL_PREFERRED   1

--- a/syscall.c
+++ b/syscall.c
@@ -139,6 +139,16 @@
 
 #endif
 
+#if !defined(__NR_set_mempolicy_home_node)
+
+#if defined(__x86_64__) || defined(__aarch64__)
+#define __NR_set_mempolicy_home_node 450
+#else
+#error "Add syscalls for your architecture or update kernel headers"
+#endif
+
+#endif
+
 #ifndef __GLIBC_PREREQ
 # define __GLIBC_PREREQ(x,y) 0
 #endif
@@ -247,6 +257,11 @@ long WEAK move_pages(int pid, unsigned long count,
 	void **pages, const int *nodes, int *status, int flags)
 {
 	return syscall(__NR_move_pages, pid, count, pages, nodes, status, flags);
+}
+
+int WEAK set_mempolicy_home_node(void *start, unsigned long len, int home_node, int flags)
+{
+   return syscall(__NR_set_mempolicy_home_node, start, len, home_node, flags);
 }
 
 /* SLES8 glibc doesn't define those */

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -164,3 +164,11 @@ libnuma_1.6{
   local:
     *;
 } libnuma_1.5;
+
+libnuma_1.7{
+  global:
+    numa_has_home_node;
+    numa_set_mempolicy_home_node;
+  local:
+    *;
+} libnuma_1.6;


### PR DESCRIPTION
add numa_set_mempolicy_home_node to set home_node for mbind or preferred_many policy.

link: https://lore.kernel.org/all/20211202123810.267175-3-aneesh.kumar@linux.ibm.com/T/#u