### PR TITLE
man pages: fix table include preprocessor

### DIFF
--- a/memhog.8
+++ b/memhog.8
@@ -1,3 +1,4 @@
+'\" t
 .TH MEMHOG 8 "2003,2004" "SuSE Labs" "Linux Administrator's Manual"
 .SH NAME
 memhog \- Allocates memory with policy for testing

--- a/migratepages.8
+++ b/migratepages.8
@@ -1,4 +1,4 @@
-.\" t
+'\" t
 .\" Copyright 2005-2006 Christoph Lameter, Silicon Graphics, Inc.
 .\"
 .\" based on Andi Kleen's numactl manpage

--- a/migspeed.8
+++ b/migspeed.8
@@ -1,4 +1,4 @@
-.\" t
+'\" t
 .\" Copyright 2005-2007 Christoph Lameter, Silicon Graphics, Inc.
 .\"
 .\" based on Andi Kleen's numactl manpage

--- a/numactl.8
+++ b/numactl.8
@@ -1,4 +1,4 @@
-.\" t
+'\" t
 .\" Copyright 2003,2004 Andi Kleen, SuSE Labs.
 .\"
 .\" Permission is granted to make and distribute verbatim copies of this


### PR DESCRIPTION
lintian in Debian started complaining

 W: numactl: groff-message an.tmac:<standard input>:110: warning: tbl
 preprocessor failed, or it or soelim was not run; table(s) likely not
 rendered (TE macro called with TW register undefined)

for these man pages.  I would claim to barely understand the ancient ruins that are man page header macros, but from what I can divine from [1] what we're looking at here is an incorrect inclusion of the "tbl" preprocessor, which should be '\" t not .\" t.

This silences the warnings, at least.

[1] https://manpages.debian.org/bookworm/man-db/man.1.en.html#DEFAULTS