### PR TITLE
Fix some warning thrown by static checking tools

### DIFF
--- a/numactl.c
+++ b/numactl.c
@@ -195,6 +195,7 @@ static void show(void)
 	printmask("nodebind", cpubind);
 	printmask("membind", membind);
 	printmask("preferred", preferred);
+	numa_bitmask_free(preferred);
 }
 
 static char *fmt_mem(unsigned long long mem, char *buf)

--- a/numademo.c
+++ b/numademo.c
@@ -250,6 +250,8 @@ static void memtest(char *name, unsigned char *mem)
 
 #endif
 		default:
+			gettimeofday(&start,NULL);
+			gettimeofday(&end,NULL);
 			break;
 		}
 


### PR DESCRIPTION
Fix warning:
numactl.c:189: leaked_storage: Variable ""preferred"" going out of scope leaks the storage it points to.                                       #  187|           printmask(""membind"", membind);
#  188|           printmask(""preferred"", preferred);                                                          
#  189|-> }

And
numademo.c:153: var_decl: Declaring variable ""end"" without initializer.
