### PR TITLE
libnuma: Return node 0 if no bit is found

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -1910,6 +1910,7 @@ int numa_preferred(void)
 
 	bmp = __numa_preferred();
 	first_node = numa_find_first(bmp);
+	first_node = first_node >= 0 ? first_node : 0;
 	numa_bitmask_free(bmp);
 	
 	return first_node;


### PR DESCRIPTION
numa_find_first() may return -1 if it finds no bit. But the numa node index should not be below zero. Hence enforcing it to be zero if less than zero.