### PR TITLE
Make numa_available respect EPERM

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -871,7 +871,7 @@ long numa_node_size(int node, long *freep)
 
 int numa_available(void)
 {
-	if (get_mempolicy(NULL, NULL, 0, 0, 0) < 0 && errno == ENOSYS)
+	if (get_mempolicy(NULL, NULL, 0, 0, 0) < 0 && (errno == ENOSYS || errno == EPERM))
 		return -1;
 	return 0;
 }


### PR DESCRIPTION
Make numa_available respect EPERM

In the Docker environment, usage of `get_mempolicy` is restricted by seccomp security profiles: https://docs.docker.com/engine/security/seccomp/ (unless `CAP_SYS_NICE` is set).

But `numa_available` used to ignore EPERM and return 'true', i.e., available. This led to further code attempting other API calls, which resulted in "operation not permitted" errors printed to stderr.

See details in:
https://github.com/ClickHouse/ClickHouse/issues/68747#issuecomment-2426210768