### PR TITLE
Fix some uninitialized variables reported by memory sanitizer

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -862,7 +862,7 @@ make_internal_alias(numa_node_size64);
 
 long numa_node_size(int node, long *freep)
 {
-	long long f2;
+	long long f2 = 0;
 	long sz = numa_node_size64_int(node, &f2);
 	if (freep)
 		*freep = f2;
@@ -1249,8 +1249,8 @@ SYMVER("numa_get_membind_v2", "numa_get_membind@@libnuma_1.2")
 struct bitmask *
 numa_get_membind_v2(void)
 {
-	int oldpolicy;
-	struct bitmask *bmp;
+	int oldpolicy = 0;
+	struct bitmask *bmp = NULL;
 
 	bmp = numa_allocate_nodemask();
 	if (!bmp)

--- a/libnuma.c
+++ b/libnuma.c
@@ -1050,7 +1050,7 @@ SYMVER("numa_get_interleave_mask_v1", "numa_get_interleave_mask@libnuma_1.1")
 nodemask_t
 numa_get_interleave_mask_v1(void)
 {
-	int oldpolicy;
+	int oldpolicy = 0;
 	struct bitmask *bmp;
 	nodemask_t mask;
 
@@ -1070,7 +1070,7 @@ SYMVER("numa_get_interleave_mask_v2", "numa_get_interleave_mask@@libnuma_1.2")
 struct bitmask *
 numa_get_interleave_mask_v2(void)
 {
-	int oldpolicy;
+	int oldpolicy = 0;
 	struct bitmask *bmp;
 
 	bmp = numa_allocate_nodemask();
@@ -1226,7 +1226,7 @@ SYMVER("numa_get_membind_v1", "numa_get_membind@libnuma_1.1")
 nodemask_t
 numa_get_membind_v1(void)
 {
-	int oldpolicy;
+	int oldpolicy = 0;
 	struct bitmask *bmp;
 	nodemask_t nmp;
 
@@ -1883,7 +1883,7 @@ out:
 
 static struct bitmask *__numa_preferred(void)
 {
-	int policy;
+	int policy = 0;
 	struct bitmask *bmp;
 
 	bmp = numa_allocate_nodemask();


### PR DESCRIPTION
Example report

```
==352==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5601962f55a3 in numa_get_membind_v2 build_docker/./contrib/numactl/libnuma.c:1259:6
    #1 0x5601951b371c in DB::getNumaNodesTotalMemory() build_docker/./base/base/Numa.cpp:18:26
    #2 0x56017338880d in DB::Server::main(std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>> const&) build_docker/./programs/server/Server.cpp:905:34
    #3 0x5601954a2d7e in Poco::Util::Application::run() build_docker/./base/poco/Util/src/Application.cpp:315:8
    #4 0x560173379f8a in DB::Server::run() build_docker/./programs/server/Server.cpp:533:25
    #5 0x5601954ea05f in Poco::Util::ServerApplication::run(int, char**) build_docker/./base/poco/Util/src/ServerApplication.cpp:131:9
    #6 0x560173372a68 in mainEntryClickHouseServer(int, char**) build_docker/./programs/server/Server.cpp:339:20
    #7 0x56015c64fc49 in main build_docker/./programs/main.cpp:248:21
    #8 0x7f4bacb60d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #9 0x7f4bacb60e3f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x29e3f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)
    #10 0x56015c5c302d in _start (/usr/bin/clickhouse+0x843e02d) (BuildId: c4cadf27cb702ae1fba66f66759ab75c588d398d)

  Uninitialized value was created by an allocation of 'oldpolicy' in the stack frame
    #0 0x5601962f5401 in numa_get_membind_v2 build_docker/./contrib/numactl/libnuma.c:1252:2

SUMMARY: MemorySanitizer: use-of-uninitialized-value build_docker/./contrib/numactl/libnuma.c:1259:6 in numa_get_membind_v2
Exiting
```