### PR TITLE
libnuma: support weighted-interleaved allocations

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -894,6 +894,12 @@ numa_interleave_memory_v2(void *mem, size_t size, struct bitmask *bmp)
 	dombind(mem, size, MPOL_INTERLEAVE, bmp);
 }
 
+void
+numa_weighted_interleave_memory(void *mem, size_t size, struct bitmask *bmp)
+{
+	dombind(mem, size, MPOL_WEIGHTED_INTERLEAVE, bmp);
+}
+
 void numa_tonode_memory(void *mem, size_t size, int node)
 {
 	struct bitmask *nodes;
@@ -1005,6 +1011,25 @@ void *
 numa_alloc_interleaved(size_t size)
 {
 	return numa_alloc_interleaved_subset_v2_int(size, numa_all_nodes_ptr);
+}
+
+void *
+numa_alloc_weighted_interleaved_subset(size_t size, struct bitmask *bmp)
+{
+	char *mem;
+
+	mem = mmap(0, size, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS,
+		   0, 0);
+	if (mem == (char *)-1)
+		return NULL;
+	dombind(mem, size, MPOL_WEIGHTED_INTERLEAVE, bmp);
+	return mem;
+}
+
+void *
+numa_alloc_weighted_interleaved(size_t size)
+{
+	return numa_alloc_weighted_interleaved_subset(size, numa_all_nodes_ptr);
 }
 
 /*

--- a/numa.3
+++ b/numa.3
@@ -84,6 +84,8 @@ numa \- NUMA policy library
 .br
 .BI "void numa_interleave_memory(void *" start ", size_t " size ", struct bitmask *" nodemask );
 .br
+.BI "void numa_weighted_interleave_memory(void *" start ", size_t " size ", struct bitmask *" nodemask );
+.br
 .BI "void numa_bind(struct bitmask *" nodemask );
 .br
 .BI "void numa_set_localalloc(void);
@@ -101,6 +103,10 @@ numa \- NUMA policy library
 .BI "void *numa_alloc_interleaved(size_t " size );
 .br
 .BI "void *numa_alloc_interleaved_subset(size_t " size ",  struct bitmask *" nodemask );
+.br
+.BI "void *numa_alloc_weighted_interleaved(size_t " size );
+.br
+.BI "void *numa_alloc_weighted_interleaved_subset(size_t " size ", struct bitmask *" nodemask );
 .br
 .BI "void *numa_alloc(size_t " size );
 .br
@@ -538,6 +544,41 @@ If the
 flag is true then the operation will cause a numa_error if there were already
 pages in the mapping that do not follow the policy.
 
+.BR numa_weighted_interleave_memory ()
+interleaves
+.I size
+bytes of memory page by page from
+.I start
+on nodes specified in
+.IR nodemask
+according to the weights in
+.I /sys/kernel/mm/mempolicy/weighted_interleave/node*.
+The
+.I size
+argument will be rounded up to a multiple of the system page size.
+If
+.I nodemask
+contains nodes that are externally denied to this process,
+this call will fail.
+This is a lower level function to interleave allocated but not yet faulted in
+memory. Not yet faulted in means the memory is allocated using
+.BR mmap (2)
+or
+.BR shmat (2),
+but has not been accessed by the current process yet. The memory is page
+interleaved to all nodes specified in
+.IR nodemask .
+Normally
+.BR numa_alloc_weighted_interleaved ()
+should be used for private memory instead, but this function is useful to
+handle shared memory areas. To be useful the memory area should be
+several megabytes at least (or tens of megabytes of hugetlbfs mappings)
+If the
+.BR numa_set_strict ()
+flag is true then the operation will cause a numa_error if there were already
+pages in the mapping that do not follow the policy.
+
+
 .BR numa_bind ()
 binds the current task and its children to the nodes
 specified in
@@ -637,11 +678,46 @@ The allocated memory must be freed with
 .BR numa_free ().
 On error, NULL is returned.
 
+.BR numa_alloc_weighted_interleaved ()
+allocates
+.I size
+bytes of memory page interleaved on all nodes according to the weights in
+.I /sys/kernel/mm/mempolicy/weighted_interleave/node*.
+This function is relatively slow and should only be used for large areas
+consisting of multiple pages. The interleaving works at page level and will
+only show an effect when the area is large.
+The allocated memory must be freed with
+.BR numa_free ().
+On error, NULL is returned.
+
 .BR numa_alloc_interleaved_subset ()
 attempts to allocate
 .I size
 bytes of memory page interleaved on nodes specified in
 .IR nodemask .
+The
+.I size
+argument will be rounded up to a multiple of the system page size.
+The nodes on which a process is allowed to allocate memory may
+be constrained externally.
+If this is the case, this function may fail.
+This function is relatively slow compared to the
+.IR malloc (3)
+family of functions and should only be used for large areas consisting
+of multiple pages.
+The interleaving works at page level and will only show an effect when the
+area is large.
+The allocated memory must be freed with
+.BR numa_free ().
+On error, NULL is returned.
+
+.BR numa_alloc_weighted_interleaved_subset ()
+attempts to allocate
+.I size
+bytes of memory page interleaved on nodes specified in
+.IR nodemask
+according to the weights in
+.I /sys/kernel/mm/mempolicy/weighted_interleave/node*.
 The
 .I size
 argument will be rounded up to a multiple of the system page size.

--- a/numa.3
+++ b/numa.3
@@ -101,6 +101,7 @@ numa \- NUMA policy library
 .BI "void *numa_alloc_interleaved(size_t " size );
 .br
 .BI "void *numa_alloc_interleaved_subset(size_t " size ",  struct bitmask *" nodemask );
+.br
 .BI "void *numa_alloc(size_t " size );
 .br
 .BI "void *numa_realloc(void *"old_addr ", size_t " old_size ", size_t " new_size );

--- a/numa.3
+++ b/numa.3
@@ -640,7 +640,8 @@ On error, NULL is returned.
 .BR numa_alloc_interleaved_subset ()
 attempts to allocate
 .I size
-bytes of memory page interleaved on all nodes.
+bytes of memory page interleaved on nodes specified in
+.IR nodemask .
 The
 .I size
 argument will be rounded up to a multiple of the system page size.

--- a/numa.h
+++ b/numa.h
@@ -223,6 +223,11 @@ int numa_get_interleave_node(void);
 void *numa_alloc_interleaved_subset(size_t size, struct bitmask *nodemask);
 /* Alloc memory page interleaved on all nodes. */
 void *numa_alloc_interleaved(size_t size);
+/* Alloc memory page interleaved on nodes in mask using weights */
+void *numa_alloc_weighted_interleaved_subset(size_t size, struct bitmask *nodemask);
+/* Alloc memory page interleaved on all nodes using weights */
+void *numa_alloc_weighted_interleaved(size_t size);
+
 /* Alloc memory located on node */
 void *numa_alloc_onnode(size_t size, int node);
 /* Alloc memory on local node */
@@ -239,6 +244,8 @@ void numa_free(void *mem, size_t size);
 
 /* Interleave a memory area. */
 void numa_interleave_memory(void *mem, size_t size, struct bitmask *mask);
+/* Interleave a memory area using weights. */
+void numa_weighted_interleave_memory(void *mem, size_t size, struct bitmask *mask);
 
 /* Allocate a memory area on a specific node. */
 void numa_tonode_memory(void *start, size_t size, int node);

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -176,6 +176,9 @@ libnuma_1.7{
 libnuma_2.1{
   global:
     numa_set_weighted_interleave_mask;
+    numa_alloc_weighted_interleaved;
+    numa_alloc_weighted_interleaved_subset;
+    numa_weighted_interleave_memory;
   local:
     *;
 } libnuma_1.7;


### PR DESCRIPTION
This PR adds weighted-interleaved allocations to libnuma APIs and a few cleanups for numa.3 man page. The description copied from the last commit:

Currently libnuma only supports per-process weighted interleaving policy. Introduce libnuma APIs to enforce specific memory mappings to be distributed in the weighted interleave mode.

To align with the existing support for the traditional interleaving, introduce three APIs, one that interleaves allocations on NUMA nodes specified in the nodemask, another that interleaves allocations on all NUMA nodes, and the other that updates the memory policy of an existing mapping:

* numa_alloc_weighted_interleaved_subset(size, bitmask)
* numa_alloc_weighted_interleaved(size)
* numa_weighted_interleave_memory(start, size, nodemask)

Close #237