### PR TITLE
numademo: Add tests for weighted-interleaved allocations

### DIFF
--- a/numademo.c
+++ b/numademo.c
@@ -339,6 +339,7 @@ static void test(enum test type)
 	memtest("local memory", numa_alloc_local(msize));
 
 	memtest("memory interleaved on all nodes", numa_alloc_interleaved(msize));
+	memtest("memory weighted interleaved on all nodes", numa_alloc_weighted_interleaved(msize));
 	for (i = 0; i < numnodes; i++) {
 		if (regression_testing && (i % fract_nodes)) {
 		/* for regression testing (-t) do only every eighth node */
@@ -374,6 +375,7 @@ static void test(enum test type)
 				strcat(buf, buf2);
 			}
 		memtest(buf, numa_alloc_interleaved_subset(msize, nodes));
+		memtest(buf, numa_alloc_weighted_interleaved_subset(msize, nodes));
 
 		if (!numa_has_preferred_many())
 			continue;
@@ -408,6 +410,20 @@ static void test(enum test type)
 		numa_set_interleave_mask(nodes);
 		memtest("manual interleaving on first two nodes", numa_alloc(msize));
 		printf("current interleave node %d\n", numa_get_interleave_node());
+
+	}
+
+	numa_set_weighted_interleave_mask(numa_all_nodes_ptr);
+	memtest("manual interleaving to all nodes", numa_alloc(msize));
+
+	if (numnodes > 0) {
+		numa_bitmask_clearall(nodes);
+		numa_bitmask_setbit(nodes, node_to_use[0]);
+		numa_bitmask_setbit(nodes, node_to_use[1]);
+		numa_set_weighted_interleave_mask(nodes);
+		memtest("manual weighted interleaving on first two nodes", numa_alloc(msize));
+		printf("current weighted interleave node %d\n", numa_get_interleave_node());
+
 	}
 
 	numa_bitmask_free(nodes);
@@ -431,12 +447,19 @@ static void test(enum test type)
 		memtest("memory interleaved on all nodes",
 			numa_alloc_interleaved(msize));
 
+		memtest("memory weighted interleaved on all nodes",
+			numa_alloc_weighted_interleaved(msize));
+
+
 		if (numnodes >= 2) {
 			numa_bitmask_clearall(nodes);
 			numa_bitmask_setbit(nodes, node_to_use[0]);
 			numa_bitmask_setbit(nodes, node_to_use[1]);
 			memtest("memory interleaved on first two nodes",
 				numa_alloc_interleaved_subset(msize, nodes));
+			memtest("memory weighted interleaved on first two nodes",
+				numa_alloc_weighted_interleaved_subset(msize, nodes));
+
 		}
 
 		for (k = 0; k < numnodes; k++) {

--- a/util.c
+++ b/util.c
@@ -92,6 +92,7 @@ static struct policy {
 	{ "membind",    MPOL_BIND, },
 	{ "preferred",   MPOL_PREFERRED, },
 	{ "default",    MPOL_DEFAULT, 1 },
+	{ "weighted-interleave", MPOL_WEIGHTED_INTERLEAVE, },
 	{ NULL },
 };
 


### PR DESCRIPTION
This PR adds tests for the following weighted-interleaved allocations APIs in numademo.c as mentioned in [1]:
```
  numa_alloc_weighted_interleaved_subset(size, bitmask)
  numa_alloc_weighted_interleaved(size)
```
It aligns with the tests for existing NUMA allocation APIs.

In my understand, regression test codes in numactl are `numademo.c` and `test/regress`, is that correct?

`numademo.c` allocates memory with various numa_alloc APIs and measures allocation throughput. I'm wondering if it is sufficient to determine if a regression has occured.
I'm not familiar with regression testing, so I'm curious about how it's conducted.

[1] https://github.com/numactl/numactl/pull/238#issuecomment-2541867063