### PR TITLE
Better support for MPOL_WEIGHTED_INTERLEAVE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ dist_man_MANS = move_pages.2 numa.3 numactl.8 numastat.8 migratepages.8 migspeed
 
 EXTRA_DIST = README.md INSTALL.md LICENSE.GPL2 LICENSE.LGPL2.1
 
-numactl_SOURCES = numactl.c util.c shm.c shm.h VERSION
+numactl_SOURCES = numactl.c util.c sysfs.c shm.c shm.h VERSION
 numactl_LDADD = libnuma.la
 numactl_CFLAGS = $(AM_CFLAGS) -DVERSION=\"$(shell cat ${srcdir}/VERSION)\"
 

--- a/libnuma.c
+++ b/libnuma.c
@@ -1107,6 +1107,21 @@ numa_get_interleave_mask_v2(void)
 	return bmp;
 }
 
+struct bitmask *
+numa_get_weighted_interleave_mask(void)
+{
+	int oldpolicy = 0;
+	struct bitmask *bmp;
+
+	bmp = numa_allocate_nodemask();
+	if (!bmp)
+		return NULL;
+	getpol(&oldpolicy, bmp);
+	if (oldpolicy != MPOL_WEIGHTED_INTERLEAVE)
+		copy_bitmask_to_bitmask(numa_no_nodes_ptr, bmp);
+	return bmp;
+}
+
 /* (undocumented) */
 int numa_get_interleave_node(void)
 {

--- a/numa.3
+++ b/numa.3
@@ -84,6 +84,10 @@ numa \- NUMA policy library
 .br
 .BI "void numa_interleave_memory(void *" start ", size_t " size ", struct bitmask *" nodemask );
 .br
+.B struct bitmask *numa_get_weighted_interleave_mask(void);
+.br
+.BI "void numa_set_weighted_interleave_mask(struct bitmask *" nodemask );
+.br
 .BI "void numa_weighted_interleave_memory(void *" start ", size_t " size ", struct bitmask *" nodemask );
 .br
 .BI "void numa_bind(struct bitmask *" nodemask );
@@ -511,6 +515,25 @@ target.
 .\" .BR numa_alloc_interleaved ()
 .\" or
 .\" .BR numa_alloc_interleaved_subset ().
+
+.BR numa_get_weighted_interleave_mask ()
+returns the current weighted interleave mask if the task's memory
+allocation policy is weighted interleaving.
+Otherwise, this function returns an empty mask.
+
+.BR numa_set_weighted_interleave_mask ()
+sets the memory weighted interleave mask for the current task to
+.IR nodemask .
+All new memory allocations
+are weighted-interleaved over all nodes in the weighted interleave mask,
+according to the weights in
+.I /sys/kernel/mm/mempolicy/weighted_interleave/node*.
+Interleaving can be turned off again by passing an empty mask
+.RI ( numa_no_nodes ) .
+The weighted interleaving only occurs on the actual page fault that puts a
+new page into the current address space. It is also only a hint: the kernel
+will fall back to other nodes if no memory is available on the weighted
+interleave target.
 
 .BR numa_interleave_memory ()
 interleaves

--- a/numa.h
+++ b/numa.h
@@ -178,6 +178,9 @@ void numa_set_weighted_interleave_mask(struct bitmask *nodemask);
 /* Return the current interleaving mask */
 struct bitmask *numa_get_interleave_mask(void);
 
+/* Return the current weighted interleaving mask */
+struct bitmask *numa_get_weighted_interleave_mask(void);
+
 /* allocate a bitmask big enough for all nodes */
 struct bitmask *numa_allocate_nodemask(void);
 

--- a/numactl.c
+++ b/numactl.c
@@ -198,7 +198,10 @@ static void show(void)
 	printmask("nodebind", cpubind);
 	printmask("membind", membind);
 	printmask("preferred", preferred);
+	numa_bitmask_free(cpubind);
+	numa_bitmask_free(membind);
 	numa_bitmask_free(preferred);
+	numa_bitmask_free(interleave);
 }
 
 static char *fmt_mem(unsigned long long mem, char *buf)

--- a/util.c
+++ b/util.c
@@ -96,7 +96,7 @@ static struct policy {
 	{ NULL },
 };
 
-static char *policy_names[] = { "default", "preferred", "bind", "interleave", "local", "preferred-many" };
+static char *policy_names[] = { "default", "preferred", "bind", "interleave", "local", "preferred-many", "weighted-interleave" };
 
 char *policy_name(int policy)
 {

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -176,6 +176,7 @@ libnuma_1.7{
 libnuma_2.1{
   global:
     numa_set_weighted_interleave_mask;
+    numa_get_weighted_interleave_mask;
     numa_alloc_weighted_interleaved;
     numa_alloc_weighted_interleaved_subset;
     numa_weighted_interleave_memory;


### PR DESCRIPTION
The main motivation of this PR is to improve the output of `numactl --show` command for MPOL_WEIGHTED_INTERLEAVE  policy (before/after at the end of this PR). But it also includes some improvements listed below.

This PR does:
- Introduce numa_get_weighted_interleave_mask() API.
- Document both numa_{get,set}_weighted_interleave_mask() APIs.
- Fixes memory leaks of numactl --show option (in `show()` function).
- Improves the output of `numactl --show` option.

[Cc @gmprice who introduced weighted interleaving support in libnuma]

## numactl --show for MPOL_WEIGHTED_INTERLEAVE (Before)
Currently, numactl --show does not properly support MPOL_WEIGHTED_INTERLEAVE:
```bash
  $ ./numactl --weighted-interleave=0,2,3 ./numactl --show
  policy: [6]
  preferred node: physcpubind: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
  cpubind: 0
  nodebind: 0
  membind: 0 2 3
  preferred: 0 2 3
```

## numactl --show for MPOL_WEIGHTED_INTERLEAVE (After)
After this PR, the output looks like this:
(interleavemask, interleaveweights, interleavenode is additionally printed and the policy name is not shown as "[6]" but "weighted-interleave")

```bash
  $ ./numactl --weighted-interleave=0,2,3 ./numactl --show
  policy: weighted-interleave
  preferred node: 2 (interleave next)
  interleavemask: 0 2 3
  interleaveweights: 1 1 1
  interleavenode: 2
  physcpubind: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
  cpubind: 0
  nodebind: 0
  membind: 0 2 3
  preferred: 0 2 3
```