### PR TITLE
Introduce numa_preferred_err() API

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -1947,7 +1947,7 @@ static struct bitmask *__numa_preferred(void)
 	return bmp;
 }
 
-int numa_preferred(void)
+int numa_preferred_err(void)
 {
 	int first_node = 0;
 	struct bitmask *bmp;
@@ -1956,6 +1956,16 @@ int numa_preferred(void)
 	first_node = numa_find_first(bmp);
 	numa_bitmask_free(bmp);
 	
+	return first_node;
+}
+
+int numa_preferred(void)
+{
+	int first_node = 0;
+
+	first_node = numa_preferred_err();
+	first_node = first_node >= 0 ? first_node : 0;
+
 	return first_node;
 }
 

--- a/numa.3
+++ b/numa.3
@@ -64,6 +64,8 @@ numa \- NUMA policy library
 .sp
 .B int numa_preferred(void);
 .br
+.B int numa_preferred_err(void);
+.br
 .B int numa_has_preferred_many(void);
 .br
 .B struct bitmask *numa_preferred_many(void);
@@ -447,6 +449,10 @@ allocates memory, unless some other policy overrides this.
 .\" patches go in.  In the latter case, we'd need to know the
 .\" order of the current node's zonelist to return the correct
 .\" node.  Need to tighten this up with the syscall results.
+
+.BR numa_preferred_err ()
+Similiar to numa_preferred(), but If the preferred node is unavailable,
+return an error instead of zero.
 
 .BR numa_has_preferred_many ()
 Returns > 0 if the system supports multiple preferred nodes.

--- a/numa.h
+++ b/numa.h
@@ -140,6 +140,9 @@ int numa_max_node(void);
 int numa_max_possible_node(void);
 /* Return preferred node */
 int numa_preferred(void);
+/* If the preferred node is unavailable, return an error;
+   otherwise, return the preferred node */
+int numa_preferred_err(void);
 
 /* Return node size and free memory */
 long long numa_node_size64(int node, long long *freep);

--- a/versions.ldscript
+++ b/versions.ldscript
@@ -45,6 +45,7 @@ libnuma_1.1 {
     numa_parse_bitmap;
     numa_police_memory;
     numa_preferred;
+    numa_preferred_err;
     numa_run_on_node;
     numa_run_on_node_mask;
     numa_sched_getaffinity;


### PR DESCRIPTION
After commit 87c6834 ( libnuma: Convert preferred node into a mask), numa_preferred() returns -1 if no suitable node is found. Before that, it returns 0.

Some users still expect the old behavior, and they use 0 as an index to an array. Let's clarify here that this is incorrect.