### PR TITLE
numastat command fails on LPAR which is not having node0

### DIFF
--- a/numastat.c
+++ b/numastat.c
@@ -782,8 +782,9 @@ static void show_info_from_system_file(char *file, int tok_offset)
 {
         char fname[64];
         char buf[SMALL_BUF_SIZE];
-        // Open /sys/.../node0/<file>
-        snprintf(fname, sizeof(fname), "/sys/devices/system/node/node0/%s", file);
+	
+	// Use the first available node for initial row counting
+	snprintf(fname, sizeof(fname), "/sys/devices/system/node/node%d/%s", node_ix_map[0], file);
         FILE *fs = fopen(fname, "r");
         if (!fs) {
                 sprintf(buf, "cannot open %s", fname);


### PR DESCRIPTION
We see the device path hardcoded with node0.
it presumes node0 always exist, and it just counts the number of rows of information in the file for later uses where it does process the nodes as expected.

Before patch - 

#numastat

cannot open /sys/devices/system/node/node0/numastat: No such file or directory

After patch 

#numastat
                                 node1
numa_hit                 2656761
numa_miss                      0
numa_foreign                   0
interleave_hit               556
local_node               2656761
other_node                     0

