### PR TITLE
Fix init race for specific libnuma calls

### DIFF
--- a/libnuma.c
+++ b/libnuma.c
@@ -80,7 +80,7 @@ static int numproccpu = -1;
 static int nodemask_sz = 0;
 static int cpumask_sz = 0;
 
-static int has_preferred_many = -1;
+static int has_preferred_many = 0;
 
 int numa_exit_on_error = 0;
 int numa_exit_on_warn = 0;
@@ -623,18 +623,13 @@ set_configured_cpus(void)
 }
 
 static void
-set_preferred_many(void)
+set_kernel_abi(void)
 {
 	int oldp;
 	struct bitmask *bmp, *tmp;
 	int old_errno;
 
-	if (has_preferred_many >= 0)
-		return;
-
 	old_errno = errno;
-
-	has_preferred_many = 0;
 
 	bmp = numa_allocate_nodemask();
 	tmp = numa_get_mems_allowed();
@@ -668,6 +663,7 @@ set_sizes(void)
 	set_numa_max_cpu();	/* size of kernel cpumask_t */
 	set_configured_cpus();	/* cpus listed in /sys/devices/system/cpu */
 	set_task_constraints(); /* cpus and nodes for current task */
+	set_kernel_abi();	/* man policy supported */
 }
 
 int
@@ -1164,7 +1160,6 @@ void *numa_alloc_local(size_t size)
 
 void numa_set_bind_policy(int strict)
 {
-	set_preferred_many();
 	if (strict)
 		bind_policy = MPOL_BIND;
 	else if (has_preferred_many)
@@ -1992,7 +1987,6 @@ void numa_set_preferred(int node)
 
 int numa_has_preferred_many(void)
 {
-	set_preferred_many();
 	return has_preferred_many;
 }
 
@@ -2000,7 +1994,6 @@ void numa_set_preferred_many(struct bitmask *bitmask)
 {
 	int first_node = 0;
 
-	set_preferred_many();
 	if (!has_preferred_many) {
 		numa_warn(W_nodeparse,
 			"Unable to handle MANY preferred nodes. Falling back to first node\n");


### PR DESCRIPTION
Reverts: fd4ec69686ec
Handles [issue#248](https://github.com/numactl/numactl/issues/248)
The affected code called numa_set_bind_policy() even before numa_init run through via malloc hooks.

While this is not supported, it worked before fd4ec69686ec. numa_set_bind_policy did not call set_preferred_many which needs numanode_sz to be initialized as it calls numa_allocate_nodemask.

The idea of this patch is not to support the scenario to call specific numalib functions even before numa_init, but to make sure mempolicy is set early in numa_init and somewhat reduce calling order complexity.