### PR TITLE
Add `_GNU_SOURCE` to additional files 

### DIFF
--- a/distance.c
+++ b/distance.c
@@ -16,7 +16,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
    All calls are undefined when numa_available returns an error. */
-#define _GNU_SOURCE 1
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/libnuma.c
+++ b/libnuma.c
@@ -17,7 +17,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
    All calls are undefined when numa_available returns an error. */
-#define _GNU_SOURCE 1
+#define _GNU_SOURCE
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -1979,7 +1979,7 @@ int numa_preferred_err(void)
 	bmp = __numa_preferred();
 	first_node = numa_find_first(bmp);
 	numa_bitmask_free(bmp);
-	
+
 	return first_node;
 }
 

--- a/memhog.c
+++ b/memhog.c
@@ -15,6 +15,7 @@
    on your Linux system; if not, write to the Free Software Foundation,
    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA */
 
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/migspeed.c
+++ b/migspeed.c
@@ -4,6 +4,7 @@
  * (C) 2007 Silicon Graphics, Inc. Christoph Lameter <clameter@sgi.com>
  *
  */
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include "numa.h"

--- a/numademo.c
+++ b/numademo.c
@@ -17,7 +17,7 @@
    You should find a copy of v2 of the GNU General Public License somewhere
    on your Linux system; if not, write to the Free Software Foundation,
    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA */
-#define _GNU_SOURCE 1
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/shm.c
+++ b/shm.c
@@ -17,7 +17,7 @@
    on your Linux system; if not, write to the Free Software Foundation,
    Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA */
 
-#define _GNU_SOURCE 1
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/syscall.c
+++ b/syscall.c
@@ -13,6 +13,8 @@
    You should find a copy of v2.1 of the GNU Lesser General Public License
    somewhere on your Linux system; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA */
+
+#define _GNU_SOURCE
 #include <unistd.h>
 #include <sys/types.h>
 #include <asm/unistd.h>

--- a/syscall.c
+++ b/syscall.c
@@ -13,7 +13,6 @@
    You should find a copy of v2.1 of the GNU Lesser General Public License
    somewhere on your Linux system; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA */
-
 #define _GNU_SOURCE
 #include <unistd.h>
 #include <sys/types.h>

--- a/sysfs.c
+++ b/sysfs.c
@@ -1,5 +1,5 @@
 /* Utility functions for reading sysfs values */
-#define _GNU_SOURCE 1
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/tbitmap.c
+++ b/test/tbitmap.c
@@ -1,5 +1,5 @@
 /* Unit test bitmap parser */
-#define _GNU_SOURCE 1
+#define _GNU_SOURCE
 //#include <asm/bitops.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
When building with `clang` with `-std=c99` I encountered some errors in which `_GNU_SOURCE` was not declared in all files that needed it. In addition, normally one only needs to declare `_GNU_SOURCE`, not assign it a value; this caused some problems when I initially tried to pass `-D_GNU_SOURCE` through via the compiler. 