### PR TITLE
Fix missing value in numa_set_bind_policy documentation

### DIFF
--- a/numa.3
+++ b/numa.3
@@ -897,7 +897,7 @@ use the preferred policy or a strict policy.
 The preferred policy allows the kernel
 to allocate memory on other nodes when there isn't enough free
 on the target node. strict will fail the allocation in that case.
-Setting the argument to specifies strict, 0 preferred.
+Setting the argument to 1 specifies strict, 0 preferred.
 Note that specifying more than one node non strict may only use
 the first node in some kernel versions.
 


### PR DESCRIPTION
The sentence describing the `strict` argument in `numa_set_bind_policy` was missing a value:

```
Setting the argument to specifies strict, 0 preferred.
```

In the implementation, any non-zero value makes `strict` active.  
To keep documentation changes minimal, it has been updated to specify 1 for the strict parameter:

```
Setting the argument to 1 specifies strict, 0 preferred.
```